### PR TITLE
Added amp-user-notification with a backend service

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ $ gulp
 $ open http://localhost:8000/index.html
 ```
 
+ Some components, like the [amp-user-notification with server endpoint](https://amp-by-example.appspot.com/amp-user-notification_with_server_enpoint.html) require an additional server endpoint.
+ 
 ## Writing the sample
 
 Use HTML comments (`<!-- ... -->`) to document your sample code:

--- a/src/amp-user-notification_with_local_storage.html
+++ b/src/amp-user-notification_with_local_storage.html
@@ -1,8 +1,8 @@
 <!--
   #### Introduction
 
-  Use amp-user-notification to display a dismissable notification to the user.
-  Use this to implement a dialog to notify EU users about cookies.
+  Use `amp-user-notification` to display a dismissable notification to the user.
+  Use this to implement a dialog to notify users about cookies.
 -->
 <!doctype html>
 <html ⚡>
@@ -22,8 +22,9 @@
     }
     amp-user-notification {
       padding: 8px;
-      background-color: beige;
+      background: beige;
     }
+
   </style>
   <style>body {opacity: 0}</style><noscript><style>body {opacity: 1}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
@@ -32,13 +33,11 @@
 
   <!-- #### Using Local Storage -->
   <!--
-    When using the local storage solution, the parameters data-show-if-href and
-    data-dismiss-if-href are optional. When the user agrees to the cookies policy,
-    a new item is added to the local storage.
+    When the user agrees to the cookies policy, the status is saved in the local storage. 
   -->
   <amp-user-notification layout=nodisplay id="amp-user-notification1">
     This is an amp-user-notification. It uses local storage to store the dissmissed state.
-    <a on="tap:amp-user-notification1.dismiss" class="dismiss">Dismiss</a>
+    <button on="tap:amp-user-notification1.dismiss">I accept</button>
   </amp-user-notification>
 
 </body>

--- a/src/amp-user-notification_with_server_endpoint.html
+++ b/src/amp-user-notification_with_server_endpoint.html
@@ -1,0 +1,60 @@
+<!--
+  #### Introduction
+
+  Use `amp-user-notification` to display a dismissable notification to the user.
+  Combine it with a server endpoint if you want to store the dismissal 
+  state across your AMP articles and your normal articles.
+-->
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <!-- #### Setup -->
+  <!-- Import the amp-user-notification component in the header. -->
+  <script async custom-element="amp-user-notification" src="https://cdn.ampproject.org/v0/amp-user-notification-0.1.js"></script>
+  <!--
+    Specify any additional css, by default, the `amp-user-notification` is positioned
+    in the left bottom corner.
+  -->
+  <style amp-custom>
+    footer {
+      margin-bottom: 50px;
+    }
+    amp-user-notification {
+      padding: 8px;
+      background: beige;
+    }
+  </style>
+  <style>body {opacity: 0}</style><noscript><style>body {opacity: 1}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+
+  <!-- #### Using Backend service -->
+  <!--
+    When using a backend solution, two parameters are available: `data-show-if-href` and
+    `data-dismiss-if-href`. They can be used together or separatively.
+
+    `data-show-if-href` needs to point to a server-endpoint returning 
+    `{ "showNotification": true|false }`. 
+
+    The URL defined by `data-dismiss-href` will be called when the notification is dismissed.
+
+    You can find a sample implementation [here](https://github.com/ampproject/amp-publisher-sample/blob/master/controllers/amp-user-notification/api.js).
+
+    If the notification has already been dismissed and the related item has been added to
+    the localstorage, the notification will not appear even if you have configured 
+    `data-show-if-href` and `data-dismiss-href`.
+  -->
+  <amp-user-notification layout=nodisplay id="amp-user-notification1"
+      data-show-if-href="https://rocky-sierra-1919.herokuapp.com/amp-user-notification/api/show?timestamp=TIMESTAMP"
+      data-dismiss-href=
+      "https://rocky-sierra-1919.herokuapp.com/amp-user-notification/api/echo/post">
+      This is an amp-user-notification. It uses a backend service
+      to verify if the notification has to be shown.
+     <button on="tap:amp-user-notification1.dismiss">I accept</button>
+  </amp-user-notification>
+
+</body>
+</html>


### PR DESCRIPTION
Added amp-user-notification with a backend service called by the parameter data-show-if-href and data-dismissed-if-href.
Added a comment on the readme pointing at the project amp-publisher-sample that can be used as a local server to demo this feature.