### PR TITLE
Support arbitrary titles

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -132,7 +132,7 @@ gulp.task('generateIndex', 'generate index.html', function() {
 
 gulp.task('create', 'create a new AMP example', function() {
   const title = process.argv[4];
-  return file(FileName.fromString(title) + '.html', '', {src: true})
+  return file(FileName.fromString(title), '', {src: true})
     .pipe(createExample('./src/templates/', 'new-example.html'))
     .pipe(gulp.dest('src'));
 });

--- a/spec/compiler/FileNameSpec.js
+++ b/spec/compiler/FileNameSpec.js
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+describe("FileName", function() {
+
+  var FileName = require('../../tasks/lib/FileName');
+
+  describe('fromString', function() {
+    it('appends .html', function() {
+      expect(FileName.fromString('file'))
+        .toEqual('file.html');
+    });
+    it('replaces whitespace with _', function() {
+      expect(FileName.fromString('A String with whitespace'))
+        .toEqual('A_String_with_whitespace.html');
+    });
+    it('URI encodes other chars', function() {
+      expect(FileName.fromString("What's possible with X?"))
+        .toEqual("What%27s_possible_with_X%3F.html");
+    });
+  });
+  describe('toString', function() {
+    it('removes file extension', function() {
+      expect(FileName.toString('file.txt'))
+        .toEqual('file');
+    });
+    it('replaces _ with space', function() {
+      expect(FileName.toString('A_String_with_whitespace'))
+        .toEqual('A String with whitespace');
+    });
+    it('URI encodes other chars', function() {
+      expect(FileName.toString("What%27s_possible_with_X%3F"))
+        .toEqual("What's possible with X?");
+    });
+  });
+
+});
+
+

--- a/src/What%27s_possible_with_amp-analytics%3F.html
+++ b/src/What%27s_possible_with_amp-analytics%3F.html
@@ -1,0 +1,81 @@
+<!--
+  #### Introduction
+
+  TODO: a quick intro
+-->
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <!-- #### Setup -->
+  <!--
+    Import the `amp-analytics` component.
+  -->
+  <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
+  <!--
+    We need `amp-iframe` to show the live analytics data.
+  -->
+  <script async custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js"></script>
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+
+  <!-- #### Basic Usage -->
+  <!--
+    TODO: Describe your example here
+  -->
+  <amp-analytics>
+  <script type="application/json">
+  {
+    "requests": {
+      "event": "https://rocky-sierra-1919.herokuapp.com/amp-analytics/ping?account=${account}&user=${userId}&event=${eventId}"
+    },
+    "vars": {
+      "account": "amp-by-example",
+      "userId": "${CLIENT_ID}"
+    },
+    "triggers": {
+      "trackPageview": {
+        "on": "visible",
+        "request": "event",
+        "vars": {
+          "eventId": "pageview"
+        }
+      },
+      "anchorClicks": {
+        "on": "click",
+        "selector": "a",
+        "request": "event",
+        "vars": {
+          "eventId": "click"
+        }
+      },
+      "scrollPings": {
+        "on": "scroll",
+        "scrollSpec": {
+          "verticalBoundaries": [25, 50, 90],
+          "horizontalBoundaries": [90]
+        },
+        "request": "event",
+        "vars": {
+          "eventId": "scroll"
+        }
+      }
+    }
+  }
+  </script>
+  </amp-analytics>
+
+  <a href="#">Here is a sample link</a>
+
+  <amp-iframe width="600" height="400"
+                          layout="responsive"
+                          sandbox="allow-scripts"
+                          frameborder="0"
+                          src="https://rocky-sierra-1919.herokuapp.com/amp-analytics/embed?account=amp-by-example">
+  </amp-iframe>
+
+</body>
+</html>

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -25,7 +25,7 @@
       <p>AMP-by-Example gives you a hands-on introduction to <a href="https://www.ampproject.org">Accelerated Mobile Pages</a> based on code and live samples. Read the <a href="https://medium.com/@sebabenz/introducing-amp-by-example-dc6118794369#.ganu8ghx6">blog post</a> for more details.</p>
         <ul>
           {{#examples}}
-          <li><a href="{{file}}.html">{{title}}</a></li>
+          <li><a href="{{file}}">{{title}}</a></li>
           {{/examples}}
         </ul>
       </main>

--- a/tasks/compile-index.js
+++ b/tasks/compile-index.js
@@ -90,7 +90,7 @@ module.exports = function(file, templateRoot, template) {
     const title = FileName.toString(file);
     fileNames.push({
       title: title,
-      file: FileName.fromString(title)
+      file: encodeURI(FileName.fromString(title))
     });
     cb();
   }
@@ -106,7 +106,7 @@ module.exports = function(file, templateRoot, template) {
     const args = {
       examples: fileNames,
       title: 'AMP by Example',
-      canonical: targetFile
+      canonical: '/'
     };
     Metadata.add(args);
     args.fileName = '';

--- a/tasks/lib/CodeSection.js
+++ b/tasks/lib/CodeSection.js
@@ -65,7 +65,7 @@ module.exports = class CodeSection {
       this.cachedMarkedDoc = marked(this.doc);
       // temporary workaround to fix anchor links breaking
       // links in the text
-      if(this.cachedMarkedDoc.trim().startsWith('<h')) {
+      if (this.cachedMarkedDoc.trim().startsWith('<h')) {
         this.cachedMarkedDoc = '<div class="anchor-trigger">' +
           this.cachedMarkedDoc +
           '</div>';

--- a/tasks/lib/FileName.js
+++ b/tasks/lib/FileName.js
@@ -20,25 +20,31 @@ const gutil = require('gulp-util');
 const path = require('path');
 
 /**
- * Replaces all whitespace with underscores. Might
- * become more sophisticated later
+ * Encodes a string into file system compatible representation.
  */
 module.exports.fromString = function(string) {
-  return string.replace(/\s+/g, '_');
+  let fileName = string.replace(/\s+/g, '_');
+  fileName = encodeURIComponent(fileName);
+  fileName = fileName.replace(/'/g,"%27");
+  fileName += '.html';
+  return fileName;
 };
 
 /**
- * Replaces all underscores with ' '.
+ * Decodes a string from a file name.
  */
 module.exports.toString = function(file) {
-  let fileName;
+  let string;
   if (typeof file === 'string') {
-    fileName = file;
+    string = file;
   } else if (typeof file.path === 'string') {
-    fileName = path.basename(file.path);
+    string = path.basename(file.path);
   } else {
     return '';
   }
-  fileName = gutil.replaceExtension(path.basename(fileName), '');
-  return fileName.replace(/_/g, ' ');
+  string = gutil.replaceExtension(path.basename(string), '');
+  string = string.replace(/_/g, ' ');
+  string = decodeURIComponent(string);
+  string = string.replace(/%27/g,"'");
+  return string;
 };

--- a/tasks/lib/Metadata.js
+++ b/tasks/lib/Metadata.js
@@ -26,7 +26,7 @@ module.exports.add = function(args) {
   const timeStamp = new Date().toISOString();
   let fileName = args.fileName;
   if (!fileName) {
-    fileName = FileName.fromString(args.title) + '.html';
+    fileName = encodeURI(FileName.fromString(args.title));
   }
   const metadata = {
     desc: 'Accelerated Mobile Pages in Action',


### PR DESCRIPTION
+ use encodeURI for file names
+ add specs for file name conversions
+ double encode links to match file name

I'm not sure double URI encoding the URLs is the best way to go. Here is how it's handled at the moment:

* Title: 'Let's go'
* Filename: 'Let%27 go'
* URL: 'Let%2527%20go' -> server decodes it automatically, decodes version matches the filename

//cc @juliantoledo @jkingyens please review



