### PR TITLE
Clear current tag after tag end

### DIFF
--- a/spec/compiler/DocumentParserSpec.js
+++ b/spec/compiler/DocumentParserSpec.js
@@ -95,6 +95,10 @@ describe("DocumentParser", function() {
             newSection('', ANOTHER_TAG + '\n', "")
         ]);
     });
+    it("resets current tag after tag end", function() {
+      var doc = parse(HEAD, COMMENT, META, LINK, HEAD_END);
+      expect(doc.sections.length).toEqual(3);
+    });
   });
 
   it("adds content in body to preview", function() {

--- a/tasks/lib/DocumentParser.js
+++ b/tasks/lib/DocumentParser.js
@@ -77,6 +77,7 @@ class DocumentParser {
         this.updateHead(line);
         if (this.endOfCurrentTag(line)) {
           this.endSection();
+          this.currentTag = '';
         }
       }
       if (line.trim().endsWith('-->')) {


### PR DESCRIPTION
Fixes error where each header line is split into a different section