### PR TITLE
add optional validation task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ addons:
     - g++-4.8
 before_script:
 - npm install -g gulp
-script: gulp test && gulp clean build
+script: gulp test && gulp validate && gulp clean build
 #before_install:
 #- openssl aes-256-cbc -K $encrypted_8592b1f8cf3c_key -iv $encrypted_8592b1f8cf3c_iv
 #  -in client-secret.json.enc -out client-secret.json -d

--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ $ gulp create --name 'Hello World'
 $ vim src/Hello_World.html
 ```
 
+Run validate to validate all examples against AMP spec:
+
+```none
+$ gulp validate
+```
+
 Run build to generate all examples:
 
 ```none
@@ -48,7 +54,7 @@ $ open http://localhost:8000/index.html
 ```
 
  Some components, like the [amp-user-notification with server endpoint](https://amp-by-example.appspot.com/amp-user-notification_with_server_enpoint.html) require an additional server endpoint.
- 
+
 ## Writing the sample
 
 Use HTML comments (`<!-- ... -->`) to document your sample code:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -31,6 +31,7 @@ const favicons = require("gulp-favicons");
 const runSequence = require('run-sequence');
 
 const index = require('./tasks/compile-index');
+const validateExample = require('./tasks/validate-example');
 const compileExample = require('./tasks/compile-example');
 const createExample = require('./tasks/create-example');
 const FileName = require('./tasks/lib/FileName');
@@ -120,6 +121,12 @@ gulp.task("compile:favicons", function() {
       .pipe(gulp.dest("dist/favicons"));
 });
 
+gulp.task('validate:example', 'validate example html files', function() {
+  return gulp.src('src/*.html')
+    .pipe(compileExample('./src/templates/', 'example.html'))
+    .pipe(validateExample('./src/templates/', 'example.html'));
+});
+
 gulp.task('compile:example', 'compile example html files', function() {
   return gulp.src('src/*.html')
     .pipe(compileExample('./src/templates/', 'example.html'))
@@ -180,6 +187,9 @@ gulp.task('default', 'Run a webserver and watch for changes', [
   'build',
   'watch',
   'serve']);
+
+gulp.task('validate', 'validate all examples', [
+  'validate:example']);
 
 gulp.task('build', 'build all resources', [
   'copy:images',

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "gcloud": "^0.27.0"
   },
   "devDependencies": {
+    "amp-validator": "^0.1.4",
     "del": "^2.2.0",
     "eslint": "^2.0.0",
     "eslint-plugin-google-camelcase": "0.0.2",

--- a/tasks/validate-example.js
+++ b/tasks/validate-example.js
@@ -42,7 +42,7 @@ module.exports = function() {
       // write file to disk, invoke validator, capture output & cleanup
       const inputFilename = path.basename(file.path);
       const tmpFile = os.tmpdir() + '/' + inputFilename;
-      fs.writeFile(tmpFile, file.contents, 'utf8', function(err) {
+      fs.writeFile(tmpFile, file.contents, encoding, function(err) {
         if (err) {
           return callback(err);
         }
@@ -64,10 +64,10 @@ module.exports = function() {
           const parsedOutput = JSON.parse(output);
           const exampleKey = 'http://localhost:30000/' + inputFilename;
           if (parsedOutput[exampleKey].success) {
-            printedOutput = 'PASS';
+            printedOutput = gutil.colors.green('PASS');
           } else {
             const errorList = parsedOutput[exampleKey].errors;
-            printedOutput = 'FAIL:\n';
+            printedOutput = gutil.colors.red('FAIL\n\n');
             errorList.forEach(function(item) {
               printedOutput += item.line + ': ' + item.reason + '\n';
             });

--- a/tasks/validate-example.js
+++ b/tasks/validate-example.js
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+"use strict";
+
+const through = require('through2');
+const gutil = require('gulp-util');
+const PluginError = gutil.PluginError;
+const os = require('os');
+const fs = require('fs');
+const cp = require('child_process');
+const path = require('path');
+
+/**
+ * Create an empty example.
+ */
+module.exports = function() {
+
+  return through.obj(function(file, encoding, callback) {
+    if (file.isNull()) {
+      return callback(null, file);
+    }
+    if (file.isStream()) {
+      this.emit('error', new PluginError('validate-example',
+            'Streams not supported!'));
+    } else if (file.isBuffer()) {
+
+
+      // write file to disk, invoke validator, capture output & cleanup
+      const inputFilename = path.basename(file.path);
+      const tmpFile = os.tmpdir() + '/' + inputFilename;
+      fs.writeFile(tmpFile, file.contents, 'utf8', function(err) {
+        if (err) {
+          return callback(err);
+        }
+        const child = cp.spawn(path.join(__dirname,
+        '../node_modules/.bin/amp-validator'),
+        ['-o', 'json', inputFilename], {
+          cwd: os.tmpdir()
+        });
+        let output = '';
+        let error = false;
+        child.stderr.on('data', function(data) {
+          output += data.toString();
+        });
+        child.stdout.on('data', function(data) {
+          output += data.toString().trim();
+        });
+        child.on('exit', function() {
+          let printedOutput = '';
+          const parsedOutput = JSON.parse(output);
+          const exampleKey = 'http://localhost:30000/' + inputFilename;
+          if (parsedOutput[exampleKey].success) {
+            printedOutput = 'PASS';
+          } else {
+            const errorList = parsedOutput[exampleKey].errors;
+            printedOutput = 'FAIL:\n';
+            errorList.forEach(function(item) {
+              printedOutput += item.line + ': ' + item.reason + '\n';
+            });
+          }
+          gutil.log('Validating example ' +
+            file.relative + ': ' + printedOutput);
+          if (!error) {
+            fs.unlink(tmpFile, function() {
+              callback();
+            });
+          }
+        });
+        child.on('error', function() {
+          error = true;
+          gutil.log('Error running validator');
+          callback();
+        });
+      });
+    }
+  });
+};


### PR DESCRIPTION
adds a "gulp validate" to invoke the runtime validator on each AMP example. If success output "PASS", otherwise output "FAIL" and show AMP validation errors from the javascript console.