### PR TITLE
skip validation for examples flagged as experiments

### DIFF
--- a/tasks/compile-example.js
+++ b/tasks/compile-example.js
@@ -95,6 +95,7 @@ module.exports = function(templateRoot, template) {
       })
       .on('end', function() {
         file.path = path.join(file.base, example.targetPath());
+        file.experimental = document.metadata.experiment;
         file.contents = new Buffer(html);
         gutil.log('Generated ' + file.relative);
         stream.push(file);

--- a/tasks/validate-example.js
+++ b/tasks/validate-example.js
@@ -36,6 +36,12 @@ module.exports = function() {
       this.emit('error', new PluginError('validate-example',
             'Streams not supported!'));
     } else if (file.isBuffer()) {
+
+      // skip over experiments which will fail validation
+      if (file.experimental) {
+        return callback(null, file);
+      }
+
       // write file to disk, invoke validator, capture output & cleanup
       const inputFilename = path.basename(file.path);
       const tmpFile = path.join(os.tmpdir(), inputFilename);


### PR DESCRIPTION
When running "gulp validate", the task will now skip over any examples that are marked as experimental since in many cases we expect them to fail.