### PR TITLE
handle escaped links

### DIFF
--- a/server.go
+++ b/server.go
@@ -63,11 +63,11 @@ func RedirectDomain(h http.Handler) http.Handler {
 		if r.Host == OLD_ADDRESS ||
 			(r.TLS == nil && !strings.HasPrefix(r.Host, "localhost")) {
 			http.Redirect(w, r, NEW_ADDRESS+r.URL.Path, http.StatusMovedPermanently)
-		} else {
-			w.Header().Add("Cache-Control", fmt.Sprintf("max-age=%d, public, must-revalidate, proxy-revalidate", MAX_AGE_IN_SECONDS))
-			// make content accessible via the Google AMP CDN
-			w.Header().Add("Access-Control-Allow-Origin", "*")
-			h.ServeHTTP(w, r)
+			return
 		}
+		w.Header().Add("Cache-Control", fmt.Sprintf("max-age=%d, public, must-revalidate, proxy-revalidate", MAX_AGE_IN_SECONDS))
+		// make content accessible via the Google AMP CDN
+		w.Header().Add("Access-Control-Allow-Origin", "*")
+		h.ServeHTTP(w, r)
 	})
 }

--- a/spec/compiler/ExampleFileSpec.js
+++ b/spec/compiler/ExampleFileSpec.js
@@ -19,25 +19,25 @@ describe("ExampleFile", function() {
   var ExampleFile = require('../../tasks/lib/ExampleFile');
 
   describe('created from path', function() {
-    var file = ExampleFile.fromPath('src/10_Hello_world\'s/What\'s%20up?.html');
+    var file = ExampleFile.fromPath('src/10_Hello-world\'s/What\'s_up_100%25?.html');
     it('extracts title', function() {
-      expect(file.title()).toBe("What's up?");
+      expect(file.title()).toBe("What's up 100%?");
     });
     it('extracts url', function() {
-      expect(file.url()).toBe("/hello_world\'s/what\'s%2520up?");
+      expect(file.url()).toBe("/hello-worlds/whats_up_100/");
     });
     it('extracts file name', function() {
-      expect(file.fileName()).toBe("What\'s%20up?.html");
+      expect(file.fileName()).toBe("What\'s_up_100%25?.html");
     });
     it('extracts category', function() {
-      expect(file.category()).toBe("Hello world's");
+      expect(file.category()).toBe("Hello-world's");
     });
     it('target path', function() {
-      expect(file.targetPath()).toBe("hello_world\'s/what\'s%20up?/index.html");
+      expect(file.targetPath()).toBe("hello-worlds/whats_up_100/index.html");
     });
     it('path on github', function() {
       expect(file.githubUrl()).toBe(
-          ExampleFile.GITHUB_PREFIX + "/10_Hello_world\'s/What\'s%20up?.html");
+          ExampleFile.GITHUB_PREFIX + "/10_Hello-world's/What\'s_up_100%25?.html");
     });
   });
 

--- a/tasks/lib/ExampleFile.js
+++ b/tasks/lib/ExampleFile.js
@@ -72,11 +72,11 @@ class ExampleFile {
 
   targetParentDir() {
     const parentDir = path.basename(path.dirname(this.filePath));
-    return this.stripNumberPrefix(parentDir).toLowerCase();
+    return this.clean(this.stripNumberPrefix(parentDir));
   }
 
   targetName() {
-    return this.name().toLowerCase();
+    return this.clean(this.name());
   }
 
   targetPath() {
@@ -89,9 +89,10 @@ class ExampleFile {
 
   url() {
     return '/' +
-      encodeURI(this.targetParentDir()) +
+      this.targetParentDir() +
       '/' +
-      encodeURI(this.targetName());
+      this.targetName() +
+      '/';
   }
 
   /** private **/
@@ -99,6 +100,9 @@ class ExampleFile {
     return string.replace(PREFIX, '');
   }
 
+  clean(string) {
+    return decodeURIComponent(string).toLowerCase().replace(/[^\w\d_-]/g, '');
+  }
 }
 
 module.exports.fromPath = fromPath;


### PR DESCRIPTION
* go backend accepts paths with and without trailing slash
* all special chars are removed from urls