### PR TITLE
Normalize doc indentation

### DIFF
--- a/spec/compiler/CodeSectionSpec.js
+++ b/spec/compiler/CodeSectionSpec.js
@@ -52,10 +52,34 @@ describe("CodeSection", function() {
       expect(section.doc).toEqual("hello\nworld\n");
     });
 
-    it("trims content", function() {
-      section.appendDoc("<!-- hello");
-      section.appendDoc("world -->");
-      expect(section.doc).toEqual("hello\nworld\n");
+    it("keeps indentation", function() {
+      section.appendDoc("<!--");
+      section.appendDoc("  hello");
+      section.appendDoc("-->");
+      expect(section.doc).toEqual("\n  hello\n\n");
+    });
+
+    it("normalizes indentation", function() {
+      section.appendDoc("  <!--");
+      section.appendDoc("    hello");
+      section.appendDoc("  -->");
+      expect(section.doc).toEqual("\n  hello\n\n");
+    });
+
+    it("handles wrong indentation", function() {
+      section.appendDoc("  <!--");
+      section.appendDoc(" x  hello");
+      section.appendDoc("  -->");
+      expect(section.doc).toEqual("\nx  hello\n\n");
+    });
+
+    it("keeps empty lines", function() {
+      section.appendDoc("  <!--");
+      section.appendDoc("  hello");
+      section.appendDoc("\n");
+      section.appendDoc("  world");
+      section.appendDoc("  -->");
+      expect(section.doc).toEqual("\nhello\n\n\nworld\n\n");
     });
 
   });

--- a/src/20_Components/amp-list.html
+++ b/src/20_Components/amp-list.html
@@ -29,21 +29,21 @@
 
   <!-- #### Using a nested template -->
   <!--
-    The `amp-list` content is provided by a JSON CORS endpoint, which is defined by the `src`
-    attribute. The URL's protocol must be HTTPS. The response must be a JSON object containing
-    an array property `items`, for example:
-    ```
-    {
+  The `amp-list` content is provided by a JSON CORS endpoint, which is defined by the `src`
+  attribute. The URL's protocol must be HTTPS. The response must be a JSON object containing
+  an array property `items`, for example:
+  ```
+  {
     "items": [
       {
         "title": "amp-carousel",
         "url": "https://ampbyexample.com/components/amp-carousel"
       },
       ...
-      ]
-    }
-    ```
-    The list content is rendered via an [amp-mustache template](https://github.com/ampproject/amphtml/blob/master/extensions/amp-mustache/amp-mustache.md). The template can either be specified using a nested element.
+    ]
+  }
+  ```
+  The list content is rendered via an [amp-mustache template](https://github.com/ampproject/amphtml/blob/master/extensions/amp-mustache/amp-mustache.md). The template can either be specified using a nested element.
   -->
   <amp-list width=300 height=100 layout=responsive
       src="https://ampbyexample.com/json/examples.json">

--- a/src/30_Advanced/Using_the_Google_AMP_Cache.html
+++ b/src/30_Advanced/Using_the_Google_AMP_Cache.html
@@ -38,13 +38,15 @@ Here are some examples for how the AMP Cache handles redirects and errors:
 **Redirects**
 
 The AMP Cache follows redirects when resolving AMP URLs. For example, if an URL redirects to another AMP URL:
-    ```
-    $ curl -I https://ampbyexample.com/amp-img.html
-    HTTP/1.1 301 Moved Permanently
-    Location: https://ampbyexample.com/components/amp-img
-    ...
-    ```
-    Then the AMP Cache will return the content of the resolved redirect for the original URL. 
+
+```
+$ curl -I https://ampbyexample.com/amp-img.html
+HTTP/1.1 301 Moved Permanently
+Location: https://ampbyexample.com/components/amp-img
+...
+```
+
+Then the AMP Cache will return the content of the resolved redirect for the original URL. 
 
 Example: [https://cdn.ampproject.org/c/s/ampbyexample.com/amp-img.html](https://cdn.ampproject.org/c/s/ampbyexample.com/amp-img.html).
     <p class="card warning">**Important**: if you move the location of the AMP Files on your server, make sure to set up a redirect from the old location to the new one. </p>

--- a/tasks/lib/CodeSection.js
+++ b/tasks/lib/CodeSection.js
@@ -24,6 +24,9 @@ marked.setOptions({
     return require('highlight.js').highlightAuto(code).value;
   }
 });
+const COMMENT_START = '<!--';
+const COMMENT_END = '-->';
+
 
 module.exports = class CodeSection {
 
@@ -40,11 +43,11 @@ module.exports = class CodeSection {
     this.id = 0;
     this.cachedMarkedDoc = false;
     this.isLastSection = true;
+    this.commentOffset = 0;
   }
 
   appendDoc(doc) {
-    doc = this.removeCommentTag(doc);
-    this.doc += doc + '\n';
+    this.doc += this.normalizeDoc(doc) + '\n';
     this.cachedMarkedDoc = false;
   }
 
@@ -76,8 +79,36 @@ module.exports = class CodeSection {
   }
 
   /* PRIVATE */
-  removeCommentTag(string) {
-    return string.replace(/\<\!--|--\>/g, '').trim();
+
+  /**
+   * Normalizes a string based on the indentation of the comment tag.
+   * Substracts the comment tag indentation from all following lines.
+   */
+  normalizeDoc(string) {
+    let startIndex = string.indexOf(COMMENT_START);
+    if (startIndex == -1) {
+      startIndex = this.stripLeadingWhitespace(string);
+    } else {
+      this.commentOffset = startIndex;
+      startIndex = startIndex + COMMENT_START.length;
+    }
+    let endIndex = string.indexOf(COMMENT_END);
+    if (endIndex == -1) {
+      endIndex = string.length;
+    }
+    return string.substring(startIndex, endIndex);
+  }
+
+  stripLeadingWhitespace(string) {
+    let startIndex = 0;
+    for (let i = 0; i < this.commentOffset; i++) {
+      if (string.charAt(i) == ' ') {
+        startIndex++;
+      } else {
+        break;
+      }
+    }
+    return startIndex;
   }
 };
 


### PR DESCRIPTION
We used to trim every doc line. This is a problem for code blocks where
the indentation is relevant (e.g. in the amp-list sample). We now
normalize docs based on the indentation of the comment tags, e.g. for:

__<--
__  text
__text
__-->

all whitespaces marked by '_' will be removed resulting in

"
  text
text
"

Fixes #68