### PR TITLE
Fixes for amp-sidebar #140:

### DIFF
--- a/src/20_Components/amp-sidebar.html
+++ b/src/20_Components/amp-sidebar.html
@@ -25,16 +25,16 @@
       width: 250px;
       padding-right: 10px;
     }
-    .amp-close-icon {
-        background-position: right top;
-        background-repeat: no-repeat;
-        background-image: -webkit-image-set(
-          url('/img/ic_close_black_18dp_1x.png') 1x,
-          url('/img/ic_close_black_18dp_2x.png') 2x );
+    .-amp-layout-container {
+      display: none;
     }
     .amp-sidebar-image {
       line-height: 100px;
       vertical-align:middle;
+    }
+    .amp-close-image {
+       top: 15px;
+       left: 225px;
     }
     li {
       margin-bottom: 20px;
@@ -56,8 +56,8 @@
     `amp-fit-text` expands or shrinks its font size to fit the content within the space given to in the menu.
   -->
     <amp-sidebar id='sidebar1'>
+      <amp-img class='amp-close-image' src="/img/ic_close_black_18dp_2x.png" width="20" height="20" alt="an image" on="tap:sidebar1.close"></amp-img>
       <ul>
-        <div class='amp-close-icon' on="tap:sidebar1.close"/>
         <li><a href="/">Home</a></li>
         <li> Nav item 1</li>
         <li>


### PR DESCRIPTION
 - Hidden when experiment is not enable.
 - Close button div was too big causing it to close anywhere.