### PR TITLE
add working example of amp-install-serviceworker

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -189,9 +189,11 @@ gulp.task('compile:sw-precache',
 
             swPrecache.write(path.join(staticDir, 'sw.js'), {
               staticFileGlobs: [
-                path.join(paths.dist.img, '*.{png,jpg,gif}'),
-                path.join(paths.dist.video, '*.{mp4,webm}'),
-                paths.dist.html
+                path.join(paths.dist.dir, 'LICENSE.txt'),
+                path.join(paths.dist.img, 'gist.png'),
+                path.join(paths.dist.img, 'abe_preview.png'),
+                path.join(paths.dist.favicons, '*.png'),
+                path.join(paths.dist.dir, 'components/amp-install-serviceworker/*.html')
               ],
               stripPrefix: 'dist',
               verbose: true

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -185,9 +185,7 @@ gulp.task('compile:sitemap', 'generate sitemap.xml', function() {
 
 gulp.task('compile:sw-precache',
   ['copy:images', 'copy:videos', 'compile:example'], function() {
-    const staticDir = 'static';
-
-    swPrecache.write(path.join(staticDir, 'sw.js'), {
+    swPrecache.write(path.join(paths.dist.dir, 'sw.js'), {
       staticFileGlobs: [
         path.join(paths.dist.dir, 'LICENSE.txt'),
         path.join(paths.dist.img, 'gist.png'),
@@ -199,28 +197,6 @@ gulp.task('compile:sw-precache',
       stripPrefix: 'dist',
       verbose: true
     });
-  });
-
-gulp.task('copy:sw-precache', ['compile:sw-precache'], function() {
-  const staticDir = 'static';
-
-  return gulp.src(path.join(staticDir, 'sw.js'))
-    .pipe(cache(staticDir))
-    .pipe(gulp.dest(paths.dist.dir));
-});
-
-gulp.task('clean:sw-precache', 'delete temporary file', function() {
-  const staticDir = 'static';
-
-  return del([path.join(staticDir, 'sw.js')]);
-});
-
-gulp.task('sw-precache', 'generate sw.js and clean temporary file',
-  function(callback) {
-    runSequence('compile:sw-precache',
-                'copy:sw-precache',
-                'clean:sw-precache',
-                callback);
   });
 
 gulp.task('create', 'create a new AMP example', function() {
@@ -327,7 +303,7 @@ gulp.task('build', 'build all resources', [
   'compile:favicons',
   'compile:sitemap',
   'compile:example',
-  'sw-precache']);
+  'compile:sw-precache']);
 
 function isFixed(file) {
   return file.eslint.fixed;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -185,22 +185,22 @@ gulp.task('compile:sitemap', 'generate sitemap.xml', function() {
 
 gulp.task('compile:sw-precache',
           ['copy:images', 'copy:videos', 'compile:example'], function() {
-  const staticDir = 'static';
+            const staticDir = 'static';
 
-  swPrecache.write(path.join(staticDir, 'sw.js'), {
-    staticFileGlobs: [
-      path.join(paths.dist.img, '*.{png,jpg,gif}'),
-      path.join(paths.dist.video, '*.{mp4,webm}'),
-      paths.dist.html
-    ],
-    stripPrefix: 'dist',
-    verbose: true
-  });
+            swPrecache.write(path.join(staticDir, 'sw.js'), {
+              staticFileGlobs: [
+                path.join(paths.dist.img, '*.{png,jpg,gif}'),
+                path.join(paths.dist.video, '*.{mp4,webm}'),
+                paths.dist.html
+              ],
+              stripPrefix: 'dist',
+              verbose: true
+            });
 
-  return gulp.src(path.join(staticDir, 'sw.js'))
-      .pipe(cache('static'))
-      .pipe(gulp.dest(paths.dist.dir));
-});
+            return gulp.src(path.join(staticDir, 'sw.js'))
+              .pipe(cache('static'))
+              .pipe(gulp.dest(paths.dist.dir));
+          });
 
 gulp.task('create', 'create a new AMP example', function() {
   const title = argv.n || argv.name;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -183,16 +183,22 @@ gulp.task('compile:sitemap', 'generate sitemap.xml', function() {
       .pipe(gulp.dest(paths.dist.dir));
 });
 
-gulp.task('compile:sw-precache', 'run sw-precache process', function() {
+gulp.task('compile:sw-precache',
+          ['copy:images', 'copy:videos', 'compile:example'], function() {
   const staticDir = 'static';
 
   swPrecache.write(path.join(staticDir, 'sw.js'), {
-    staticFileGlobs: [paths.images, paths.videos],
-    stripPrefix: 'src'
+    staticFileGlobs: [
+      path.join(paths.dist.img, '*.{png,jpg,gif}'),
+      path.join(paths.dist.video, '*.{mp4,webm}'),
+      paths.dist.html
+    ],
+    stripPrefix: 'dist',
+    verbose: true
   });
 
-  return gulp.src('static/sw.js')
-      .pipe(cache('static/sw.js'))
+  return gulp.src(path.join(staticDir, 'sw.js'))
+      .pipe(cache('static'))
       .pipe(gulp.dest(paths.dist.dir));
 });
 
@@ -299,8 +305,8 @@ gulp.task('build', 'build all resources', [
   'copy:static',
   'compile:favicons',
   'compile:sitemap',
-  'compile:sw-precache',
-  'compile:example']);
+  'compile:example',
+  'compile:sw-precache']);
 
 function isFixed(file) {
   return file.eslint.fixed;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -193,14 +193,15 @@ gulp.task('compile:sw-precache',
                 path.join(paths.dist.img, 'gist.png'),
                 path.join(paths.dist.img, 'abe_preview.png'),
                 path.join(paths.dist.favicons, '*.png'),
-                path.join(paths.dist.dir, 'components/amp-install-serviceworker/*.html')
+                path.join(paths.dist.dir,
+                   'components/amp-install-serviceworker/*.html')
               ],
               stripPrefix: 'dist',
               verbose: true
             });
 
             return gulp.src(path.join(staticDir, 'sw.js'))
-              .pipe(cache('static'))
+              .pipe(cache(staticDir))
               .pipe(gulp.dest(paths.dist.dir));
           });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -184,26 +184,44 @@ gulp.task('compile:sitemap', 'generate sitemap.xml', function() {
 });
 
 gulp.task('compile:sw-precache',
-          ['copy:images', 'copy:videos', 'compile:example'], function() {
-            const staticDir = 'static';
+  ['copy:images', 'copy:videos', 'compile:example'], function() {
+    const staticDir = 'static';
 
-            swPrecache.write(path.join(staticDir, 'sw.js'), {
-              staticFileGlobs: [
-                path.join(paths.dist.dir, 'LICENSE.txt'),
-                path.join(paths.dist.img, 'gist.png'),
-                path.join(paths.dist.img, 'abe_preview.png'),
-                path.join(paths.dist.favicons, '*.png'),
-                path.join(paths.dist.dir,
-                   'components/amp-install-serviceworker/*.html')
-              ],
-              stripPrefix: 'dist',
-              verbose: true
-            });
+    swPrecache.write(path.join(staticDir, 'sw.js'), {
+      staticFileGlobs: [
+        path.join(paths.dist.dir, 'LICENSE.txt'),
+        path.join(paths.dist.img, 'gist.png'),
+        path.join(paths.dist.img, 'abe_preview.png'),
+        path.join(paths.dist.favicons, '*.png'),
+        path.join(paths.dist.dir,
+          'components/amp-install-serviceworker/*.html')
+      ],
+      stripPrefix: 'dist',
+      verbose: true
+    });
+  });
 
-            return gulp.src(path.join(staticDir, 'sw.js'))
-              .pipe(cache(staticDir))
-              .pipe(gulp.dest(paths.dist.dir));
-          });
+gulp.task('copy:sw-precache', ['compile:sw-precache'], function() {
+  const staticDir = 'static';
+
+  return gulp.src(path.join(staticDir, 'sw.js'))
+    .pipe(cache(staticDir))
+    .pipe(gulp.dest(paths.dist.dir));
+});
+
+gulp.task('clean:sw-precache', 'delete temporary file', function() {
+  const staticDir = 'static';
+
+  return del([path.join(staticDir, 'sw.js')]);
+});
+
+gulp.task('sw-precache', 'generate sw.js and clean temporary file',
+  function(callback) {
+    runSequence('compile:sw-precache',
+                'copy:sw-precache',
+                'clean:sw-precache',
+                callback);
+  });
 
 gulp.task('create', 'create a new AMP example', function() {
   const title = argv.n || argv.name;
@@ -309,7 +327,7 @@ gulp.task('build', 'build all resources', [
   'compile:favicons',
   'compile:sitemap',
   'compile:example',
-  'compile:sw-precache']);
+  'sw-precache']);
 
 function isFixed(file) {
   return file.eslint.fixed;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -32,6 +32,7 @@ const runSequence = require('run-sequence');
 const argv = require('yargs').argv;
 const path = require('path');
 const diff = require('gulp-diff');
+const swPrecache = require('sw-precache');
 
 const compileExample = require('./tasks/compile-example');
 const sitemap = require('./tasks/compile-sitemap');
@@ -182,6 +183,19 @@ gulp.task('compile:sitemap', 'generate sitemap.xml', function() {
       .pipe(gulp.dest(paths.dist.dir));
 });
 
+gulp.task('compile:sw-precache', 'run sw-precache process', function() {
+  const staticDir = 'static';
+
+  swPrecache.write(path.join(staticDir, 'sw.js'), {
+    staticFileGlobs: [paths.images, paths.videos],
+    stripPrefix: 'src'
+  });
+
+  return gulp.src('static/sw.js')
+      .pipe(cache('static/sw.js'))
+      .pipe(gulp.dest(paths.dist.dir));
+});
+
 gulp.task('create', 'create a new AMP example', function() {
   const title = argv.n || argv.name;
   const fileName = FileName.fromString(title);
@@ -285,6 +299,7 @@ gulp.task('build', 'build all resources', [
   'copy:static',
   'compile:favicons',
   'compile:sitemap',
+  'compile:sw-precache',
   'compile:example']);
 
 function isFixed(file) {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "compression": "^1.6.1",
     "connect": "^3.4.0",
     "express": "^4.13.4",
-    "gcloud": "^0.27.0"
+    "gcloud": "^0.27.0",
+    "sw-precache": "^3.1.1"
   },
   "devDependencies": {
     "amp-validator": "^0.1.4",

--- a/src/20_Components/amp-install-serviceworker.html
+++ b/src/20_Components/amp-install-serviceworker.html
@@ -34,7 +34,13 @@
       layout="nodisplay">
   </amp-install-serviceworker>
   <!--
-  `sw.js` here is generated using [sw-precache](https://github.com/GoogleChrome/sw-precache), which generates a Service Worker JavaScript file that caches specifiled static files. See example in the repository of `sw-precache` and [gulpfile.js](https://github.com/ampproject/amp-by-example/blob/master/gulpfile.js) for how to use it. 
+  `sw.js` here is generated using [sw-precache](https://github.com/GoogleChrome/sw-precache), which generates a Service Worker JavaScript file that caches specified static files. See example in the repository of `sw-precache` and [gulpfile.js](https://github.com/ampproject/amp-by-example/blob/master/gulpfile.js) for how to use it. In this sample, when users access this AMP page for the 2nd time, the Service Worker is installed and start caching all image files and video files under root path of this domain.
+  
+  In order to confirm if the Service Worker is installed and it is working as expected, follow the procedure below:
+  1. Access to https://ampbyexample.com/components/amp-install-serviceworker/ twice.
+  2. Open Chrome Dev Tools and navigate to "Resources" tab. You may see "Service Workers" section and see `/sw.js` is installed.
+  3. Then open "Cached Storage". You'll find a lot of files whose names start with "sw-precache-v1--", which are cached images and videos.
+  4. Try accessing other components demos, say [amp-img](https://ampbyexample.com/components/amp-img/). On "Network" tab in Dev Tools, you'll find "(from ServiceWorker)" notation in the rows of image/video file fetch events.  
   -->
 
 </body>

--- a/src/20_Components/amp-install-serviceworker.html
+++ b/src/20_Components/amp-install-serviceworker.html
@@ -29,8 +29,8 @@
   The reason why the latter option is required is because of Service Worker's security protection function. For details of the security considerations of Service Worker, [see official specs](https://www.w3.org/TR/service-workers/#security-considerations). 
   -->
   <amp-install-serviceworker
-      src="https://ampbyexample.com/sw.js"
-      data-iframe-src="https://ampbyexample.com/sw.html"
+      src="https://yoshifumi-amp-demo.firebaseapp.com/sw.js"
+      data-iframe-src="https://yoshifumi-amp-demo.firebaseapp.com/sw.html"
       layout="nodisplay">
   </amp-install-serviceworker>
   <!--

--- a/src/20_Components/amp-install-serviceworker.html
+++ b/src/20_Components/amp-install-serviceworker.html
@@ -29,8 +29,8 @@
   The reason why the latter option is required is because of Service Worker's security protection function. For details of the security considerations of Service Worker, [see official specs](https://www.w3.org/TR/service-workers/#security-considerations). 
   -->
   <amp-install-serviceworker
-      src="https://yoshifumi-amp-demo.firebaseapp.com/sw.js"
-      data-iframe-src="https://yoshifumi-amp-demo.firebaseapp.com/sw.html"
+      src="https://ampbyexample.com/sw.js"
+      data-iframe-src="https://ampbyexample.com/sw.html"
       layout="nodisplay">
   </amp-install-serviceworker>
   <!--

--- a/src/20_Components/amp-install-serviceworker.html
+++ b/src/20_Components/amp-install-serviceworker.html
@@ -13,7 +13,7 @@
   <meta charset="utf-8">
   <!-- #### Setup -->
   <!--
-      Import the `amp-install-serviceworker` component.
+      Import the amp-install-serviceworker component.
   -->
   <script async custom-element="amp-install-serviceworker" src="https://cdn.ampproject.org/v0/amp-install-serviceworker-0.1.js"></script>
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
@@ -29,10 +29,13 @@
   The reason why the latter option is required is because of Service Worker's security protection function. For details of the security considerations of Service Worker, [see official specs](https://www.w3.org/TR/service-workers/#security-considerations). 
   -->
   <amp-install-serviceworker
-      src="https://yoshifumi-amp-demo.firebaseapp.com/sw.js"
-      data-iframe-src="https://yoshifumi-amp-demo.firebaseapp.com/sw.html"
+      src="https://ampbyexample.com/sw.js"
+      data-iframe-src="https://ampbyexample.com/sw.html"
       layout="nodisplay">
   </amp-install-serviceworker>
+  <!--
+  `sw.js` here is generated using [sw-precache](https://github.com/GoogleChrome/sw-precache), which generates a Service Worker JavaScript file that caches specifiled static files. See example in the repository of `sw-precache` and [gulpfile.js](https://github.com/ampproject/amp-by-example/blob/master/gulpfile.js) for how to use it. 
+  -->
 
 </body>
 </html>

--- a/src/20_Components/amp-install-serviceworker.html
+++ b/src/20_Components/amp-install-serviceworker.html
@@ -4,7 +4,8 @@
   The [amp-install-serviceworker](https://github.com/ampproject/amphtml/blob/master/extensions%2Famp-install-serviceworker%2Famp-install-serviceworker.md)
   component enables Service Worker installation via original and cached AMP pages.
   
-  This demonstration installs a Service Worker that downloads other components' demo pages using Cache API triggered by the Service Worker.
+  The benefit of Service Worker is its capability, such as runnning on background even when the browser is closed, caching required contents in advance of rendering time and sending notifications to users and so on.
+   This demonstration installs a Service Worker that downloads this demo page using Cache API triggered by the Service Worker. You can confirm that this demo works even offline once the Service Worker gets installed.
 -->
 <!-- -->
 <!doctype html>
@@ -26,7 +27,7 @@
   <!-- #### Basic Usage -->
   <!--
   amp-install-serviceworker should have both properties `src` and `data-iframe-src`; `src` is the location of Service Worker to be installed when the original AMP pages is accessed, `data-iframe-src` is the location of HTML file which calls Service Worker installation process when the cached AMP pages is accessed.
-  The reason why the latter option is required is because of Service Worker's security protection function. For details of the security considerations of Service Worker, [see official specs](https://www.w3.org/TR/service-workers/#security-considerations). 
+  The reason why the latter option is required is because browsers can't install Service Worker from other domains for security reasons. For details of the security considerations of Service Worker, [see official specs](https://www.w3.org/TR/service-workers/#security-considerations).
   -->
   <amp-install-serviceworker
       src="https://ampbyexample.com/sw.js"
@@ -40,7 +41,7 @@
   1. Access to https://ampbyexample.com/components/amp-install-serviceworker/ twice.
   2. Open Chrome Dev Tools and navigate to "Resources" tab. You may see "Service Workers" section and see `/sw.js` is installed.
   3. Then open "Cached Storage". You'll find a lot of files whose names start with "sw-precache-v1--", which are cached images and videos.
-  4. Try accessing other components demos, say [amp-img](https://ampbyexample.com/components/amp-img/). On "Network" tab in Dev Tools, you'll find "(from ServiceWorker)" notation in the rows of image/video file fetch events.  
+  4. Try accessing amp-install-serviceworker when you are offline. On "Network" tab in Dev Tools, you'll find "(from ServiceWorker)" notation in the rows of image/video file fetch events.  
   -->
 
 </body>

--- a/src/20_Components/amp-install-serviceworker.html
+++ b/src/20_Components/amp-install-serviceworker.html
@@ -5,7 +5,7 @@
   component enables Service Worker installation via original and cached AMP pages.
   
   The benefit of Service Worker is its capability, such as runnning on background even when the browser is closed, caching required contents in advance of rendering time and sending notifications to users and so on.
-   This demonstration installs a Service Worker that downloads this demo page using Cache API triggered by the Service Worker. You can confirm that this demo works even offline once the Service Worker gets installed.
+  This demonstration installs a Service Worker that caches this demo page using Cache API triggered by the Service Worker on background. You can confirm that this demo works even offline once the Service Worker gets installed.
 -->
 <!-- -->
 <!doctype html>

--- a/src/20_Components/amp-install-serviceworker.html
+++ b/src/20_Components/amp-install-serviceworker.html
@@ -1,0 +1,38 @@
+<!--
+  #### Introduction
+
+  The [amp-install-serviceworker](https://github.com/ampproject/amphtml/blob/master/extensions%2Famp-install-serviceworker%2Famp-install-serviceworker.md)
+  component enables Service Worker installation via original and cached AMP pages.
+  
+  This demonstration installs a Service Worker that downloads other components' demo pages using Cache API triggered by the Service Worker.
+-->
+<!-- -->
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <!-- #### Setup -->
+  <!--
+      Import the `amp-install-serviceworker` component.
+  -->
+  <script async custom-element="amp-install-serviceworker" src="https://cdn.ampproject.org/v0/amp-install-serviceworker-0.1.js"></script>
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+
+</head>
+<body>
+
+  <!-- #### Basic Usage -->
+  <!--
+  amp-install-serviceworker should have both properties `src` and `data-iframe-src`; `src` is the location of Service Worker to be installed when the original AMP pages is accessed, `data-iframe-src` is the location of HTML file which calls Service Worker installation process when the cached AMP pages is accessed.
+  The reason why the latter option is required is because of Service Worker's security protection function. For details of the security considerations of Service Worker, [see official specs](https://www.w3.org/TR/service-workers/#security-considerations). 
+  -->
+  <amp-install-serviceworker
+      src="https://yoshifumi-amp-demo.firebaseapp.com/sw.js"
+      data-iframe-src="https://yoshifumi-amp-demo.firebaseapp.com/sw.html"
+      layout="nodisplay">
+  </amp-install-serviceworker>
+
+</body>
+</html>

--- a/src/20_Components/amp-install-serviceworker.html
+++ b/src/20_Components/amp-install-serviceworker.html
@@ -30,18 +30,18 @@
   The reason why the latter option is required is because browsers can't install Service Worker from other domains for security reasons. For details of the security considerations of Service Worker, [see official specs](https://www.w3.org/TR/service-workers/#security-considerations).
   -->
   <amp-install-serviceworker
-      src="https://ampbyexample.com/sw.js"
+      src="/sw.js"
       data-iframe-src="https://ampbyexample.com/sw.html"
       layout="nodisplay">
   </amp-install-serviceworker>
   <!--
-  `sw.js` here is generated using [sw-precache](https://github.com/GoogleChrome/sw-precache), which generates a Service Worker JavaScript file that caches specified static files. See example in the repository of `sw-precache` and [gulpfile.js](https://github.com/ampproject/amp-by-example/blob/master/gulpfile.js) for how to use it. In this sample, when users access this AMP page for the 2nd time, the Service Worker is installed and start caching all image files and video files under root path of this domain.
+  <p class="card warning">`sw.js` here is generated using [sw-precache](https://github.com/GoogleChrome/sw-precache), which generates a [Service Worker JavaScript file](https://ampbyexample.com/sw.js) that caches specified static files. See example in the repository of `sw-precache` and [gulpfile.js](https://github.com/ampproject/amp-by-example/blob/master/gulpfile.js) for how to use it.</p> In this sample, when users access this AMP page for the 2nd time, the Service Worker is installed and start caching all image files and video files under root path of this domain.
   
   In order to confirm if the Service Worker is installed and it is working as expected, follow the procedure below:
   1. Access to https://ampbyexample.com/components/amp-install-serviceworker/ twice.
   2. Open Chrome Dev Tools and navigate to "Resources" tab. You may see "Service Workers" section and see `/sw.js` is installed.
   3. Then open "Cached Storage". You'll find a lot of files whose names start with "sw-precache-v1--", which are cached images and videos.
-  4. Try accessing amp-install-serviceworker when you are offline. On "Network" tab in Dev Tools, you'll find "(from ServiceWorker)" notation in the rows of image/video file fetch events.  
+  4. Disable your network connection and reload this page. It still works! On "Network" tab in Dev Tools, you'll find "(from ServiceWorker)" notation in the rows of image/video file fetch events.  
   -->
 
 </body>

--- a/static/sw.html
+++ b/static/sw.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html>
+    <head>
+        <title>installing service worker</title>
+        <script type="text/javascript">
+            var swsource = "https://yoshifumi-amp-demo.firebaseapp.com/sw.js";
+            if("serviceWorker" in navigator) {
+                navigator.serviceWorker.register(swsource).then(function(reg){
+                    console.log('ServiceWorker scope: ', reg.scope);
+                }).catch(function(err) {
+                    console.log('ServiceWorker registration failed: ', err);
+                });
+            };
+        </script>
+    </head>
+    <body>
+    </body>
+</html>

--- a/static/sw.html
+++ b/static/sw.html
@@ -3,7 +3,7 @@
     <head>
         <title>installing service worker</title>
         <script type="text/javascript">
-            var swsource = "https://yoshifumi-amp-demo.firebaseapp.com/sw.js";
+            var swsource = "https://ampbyexample.com/sw.js";
             if("serviceWorker" in navigator) {
                 navigator.serviceWorker.register(swsource).then(function(reg){
                     console.log('ServiceWorker scope: ', reg.scope);


### PR DESCRIPTION
Though @jmadler has already created template example of amp-install-serviceworker, as discussed in #130, I created working example of it using sw-precache as a practice of using it.

For PoC, I deployed it in https://yoshifumi-amp-demo.firebaseapp.com/components/amp-install-serviceworker/ On accessing here, the SW starts caching contents under `img` and `video`. (To install SW, you need to access there twice.)