### PR TITLE
Fix live-reload

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -83,9 +83,11 @@ gulp.task('serve', 'starts a local webserver (--port specifies bound port)',
     const server = gls.static(paths.dist.dir, port);
     server.start();
     gulp.watch([paths.dist.html], function(file) {
-      /* eslint-disable */
-      server.notify.apply(server, [file]);
-      /* eslint-enable */
+      setTimeout(function() {
+        /* eslint-disable */
+        server.notify.apply(server, [file]);
+        /* eslint-enable */
+      }, 500);
     });
   });
 


### PR DESCRIPTION
Delay live reload for 500ms after a file is changed to
make sure that all changes have been written to the file.

Fixes #191