### PR TITLE
more fine grained max age control

### DIFF
--- a/amplivelist/amp-live-list.go
+++ b/amplivelist/amp-live-list.go
@@ -15,6 +15,7 @@
 package amplivelist
 
 import (
+	"fmt"
 	"html/template"
 	"net/http"
 	"strconv"
@@ -23,6 +24,7 @@ import (
 
 const (
 	AMP_LIVE_LIST_COOKIE_NAME = "ABE_AMP_LIVE_LIST_STATUS"
+	MAX_AGE_IN_SECONDS        = 1
 )
 
 type BlogItem struct {
@@ -94,6 +96,7 @@ func createPage(newStatus int) Page {
 
 func renderAmpLiveListSample(w http.ResponseWriter, page Page) {
 	t, _ := template.ParseFiles("dist/components/amp-live-list/index.html")
+	w.Header().Set("Cache-Control", fmt.Sprintf("max-age=%d, public, must-revalidate", MAX_AGE_IN_SECONDS))
 	t.Execute(w, page)
 }
 

--- a/app.yaml
+++ b/app.yaml
@@ -18,6 +18,37 @@ threadsafe: yes
 default_expiration: 1d
 
 handlers:
+
+- url: /favicons
+  static_dir: dist/favicons
+  expiration: 30d
+  secure: always
+  http_headers:
+    Access-Control-Allow-Origin: "*"
+
+- url: /img
+  static_dir: dist/img
+  secure: always
+  http_headers:
+    Access-Control-Allow-Origin: "*"
+
+- url: /styles
+  static_dir: dist/styles
+  secure: always
+  http_headers:
+    Access-Control-Allow-Origin: "*"
+
+- url: /scripts
+  static_dir: dist/scripts
+  secure: always
+  http_headers:
+    Access-Control-Allow-Origin: "*"
+
+- url: /video
+  static_dir: video
+  secure: always
+  http_headers:
+
 - url: /.*
   script: _go_app
 

--- a/server.go
+++ b/server.go
@@ -15,19 +15,19 @@
 package hello
 
 import (
+	"amplivelist"
 	"fmt"
 	"html/template"
 	"net/http"
-	"amplivelist"
-	"strings"
 	"os"
+	"strings"
 )
 
 const (
-	MAX_AGE_IN_SECONDS       = 1
-	OLD_ADDRESS              = "amp-by-example.appspot.com"
-	NEW_ADDRESS              = "https://ampbyexample.com"
-	DIST_DIR                 = "dist"
+	MAX_AGE_IN_SECONDS = 180 // three minutes
+	OLD_ADDRESS        = "amp-by-example.appspot.com"
+	NEW_ADDRESS        = "https://ampbyexample.com"
+	DIST_DIR           = "dist"
 )
 
 var REDIRECTS [18][2]string = [18][2]string{
@@ -95,9 +95,8 @@ func RedirectDomain(h http.Handler) http.Handler {
 			http.Redirect(w, r, NEW_ADDRESS+r.URL.Path, http.StatusMovedPermanently)
 			return
 		}
-		w.Header().Add("Cache-Control", fmt.Sprintf("max-age=%d, public, must-revalidate, proxy-revalidate", MAX_AGE_IN_SECONDS))
-		// make content accessible via the Google AMP CDN
-		w.Header().Add("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Cache-Control", fmt.Sprintf("max-age=%d, public", MAX_AGE_IN_SECONDS))
+		w.Header().Set("Access-Control-Allow-Origin", "*")
 		h.ServeHTTP(w, r)
 	})
 }


### PR DESCRIPTION
* 3min for samples (no revalidation)
* 1d for images, videos, css, scripts (we currently don't have any of
  the latter two)
* 10s for amp-live-list sample
* 30d for favicons