### PR TITLE
Use standalone ABE pages for amp-form success and error page.

### DIFF
--- a/ampform/amp-form.go
+++ b/ampform/amp-form.go
@@ -25,7 +25,12 @@ const (
 	ERROR_CASE_AMP_FORM = "error"
 )
 
-func SubmitFormXHR(w http.ResponseWriter, r *http.Request) {
+func Init() {
+	http.HandleFunc("/components/amp-form/submit-form-xhr", submitFormXHR)
+	http.HandleFunc("/components/amp-form/submit-form", submitForm)
+}
+
+func submitFormXHR(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("AMP-Access-Control-Allow-Source-Origin", buildSourceOrigin(r.Host))
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method != "POST" {
@@ -42,15 +47,15 @@ func SubmitFormXHR(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte(response))
 }
 
-func SubmitForm(w http.ResponseWriter, r *http.Request) {
+func submitForm(w http.ResponseWriter, r *http.Request) {
 	if r.Method != "POST" {
 		http.Error(w, "post only", http.StatusMethodNotAllowed)
 		return
 	}
 	if isUserTryingTheErrorDemo(r.FormValue("name")) {
-		http.Redirect(w, r, fmt.Sprintf("%s/amp-form-error.html", buildSourceOrigin(r.Host)), http.StatusSeeOther)
+		http.Redirect(w, r, fmt.Sprintf("%s/amp-form-error/", buildSourceOrigin(r.Host)), http.StatusSeeOther)
 	} else {
-		http.Redirect(w, r, fmt.Sprintf("%s/amp-form-success.html", buildSourceOrigin(r.Host)), http.StatusSeeOther)
+		http.Redirect(w, r, fmt.Sprintf("%s/amp-form-success/", buildSourceOrigin(r.Host)), http.StatusSeeOther)
 	}
 }
 

--- a/server.go
+++ b/server.go
@@ -58,8 +58,7 @@ func init() {
 	http.HandleFunc("/error", returnCode500)
 	amplivelist.InitBlogs()
 	http.HandleFunc("/components/amp-live-list/", amplivelist.RenderLiveBlog)
-	http.HandleFunc("/components/amp-form/submit-form-xhr", ampform.SubmitFormXHR)
-	http.HandleFunc("/components/amp-form/submit-form", ampform.SubmitForm)
+	ampform.Init()
 	http.Handle("/", RedirectDomain(NoDirListing(http.FileServer(http.Dir(DIST_DIR)))))
 }
 

--- a/src/amp-form-error.html
+++ b/src/amp-form-error.html
@@ -1,29 +1,25 @@
+<!---{
+  "hideCode": true,
+  "hidePreview": true
+}--->
 <!doctype html>
 <html ⚡>
 <head>
+  <link rel="canonical" href="https://ampbyexample.com/amp-form-error/">
   <meta charset="utf-8">
-  <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
-  <script async src="https://cdn.ampproject.org/v0.js"></script> 
-    <style amp-custom>
-        p {
-            margin-top: 4px;
-            font-size: 20px;
-            color: #dc4e41;
-        }
-        #title {
-            text-align: center;
-            font-family: Roboto,Helvetica,Arial,sans-serif;
-            font-size: 34px;
-            line-height: 40px;
-        }
-    </style>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>  
 </head>
 <body> 
-  <h3 id="title">
-        Error page for amp-form
-  </h3>
-  <p>Thanks for trying amp-form demo with an error response. This page has been opened because you chose the amp-form with HTTP request. You can go back to the previous page.</p>
+  <!--
+  #### Error page for amp-form
+
+  Error! Thanks for trying amp-form demo. This page has been opened because you chose the amp-form with HTTP request. 
+  -->
+  <!--
+  Back to [amp-form](/components/amp-form) sample.
+  -->
+
 </body>
 </html>

--- a/src/amp-form-success.html
+++ b/src/amp-form-success.html
@@ -1,30 +1,25 @@
+<!---{
+  "hideCode": true,
+  "hidePreview": true
+}--->
 <!doctype html>
 <html ⚡>
 <head>
+  <link rel="canonical" href="https://ampbyexample.com/amp-form-success/">
   <meta charset="utf-8">
-  <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
-  <script async src="https://cdn.ampproject.org/v0.js"></script> 
-    <style amp-custom>
-        p {
-            margin-top: 4px;
-            font-size: 20px;
-            color: #ff4081;
-        }
-        #title {
-            text-align: center;
-            font-family: Roboto,Helvetica,Arial,sans-serif;
-            font-size: 34px;
-            line-height: 40px;
-        }
-    </style>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>  
 </head>
 <body> 
-  <h3 id="title">
-        Success page for amp-form
-  </h3>
-  <p>Success! Thanks for trying amp-form demo. This page has been opened because you chose the amp-form with HTTP request.</p> 
-  <p>You can go back to the previous page and go back to the example. Try to insert the word "error" as a name input in the form to see how amp-form supports errors. </p>
+  <!--
+  #### Success page for amp-form
+
+  Success! Thanks for trying amp-form demo. This page has been opened because you chose the amp-form with HTTP request.
+  Try to insert the word "error" as a name input in the form to see how amp-form handles errors. 
+  -->
+  <!--
+  Back to [amp-form](/components/amp-form) sample.
+  -->
 </body>
 </html>


### PR DESCRIPTION
Change the amp-form success and error page to be a standalone ABE page.