### PR TITLE
Add example for amp-experiment

### DIFF
--- a/src/20_Components/amp-experiment.html
+++ b/src/20_Components/amp-experiment.html
@@ -1,0 +1,113 @@
+<!---{
+    "experiment": true,
+    "component": "amp-experiment"
+  }--->
+<!-- 
+  #### Introduction
+
+  [amp-experiment](https://github.com/ampproject/amphtml/blob/master/extensions/amp-experiment/amp-experiment.md) allows to perform user experience experiments on an AMP document and collect resulting data. This is good for A/B testing new features in your AMPs.
+-->
+<!-- -->
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="https://ampbyexample.com/components/amp-img/">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+   <!-- #### Setup -->
+  <!--
+    Import the `amp-experiment` component.
+  -->
+  <script async custom-element="amp-experiment" src="https://cdn.ampproject.org/v0/amp-experiment-0.1.js"></script>
+  <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
+  <!--
+    Style different variants of the experiment by using `body[amp-x-name-of-experiment="nameOfVariant"`].
+  -->
+  <style amp-custom>
+    body[amp-x-button-color-experiment="yellow"] .button-experiment{
+      background-color: yellow;
+      color: black;
+    }
+    body[amp-x-button-color-experiment="red"] .button-experiment{
+      background-color: red;
+    }
+    body[amp-x-button-color-experiment="blue"] .button-experiment{
+      background-color: blue;
+    }
+    button {
+      background-color: grey;
+    }
+  </style>
+</head>
+<body>
+
+  <!-- #### Basic Usage -->
+  <!--
+    Configure experiments inside the `amp-experiment` inside a JSON object. Use `variants` within each experiment to declare how many users in percent will be part of an experiment variant. The total sum of the variants must be a number <= 100, if the number is < 100, then the default behaviour is used. A user belongs to one of the variants based on a random number generated between 0 and 100. For more details about variants read the official [documentation](https://github.com/ampproject/amphtml/blob/master/extensions/amp-experiment/amp-experiment.md). Multiple experiments can be run on the same AMP document in parallel with their own sets of variants. One AMP document can have at most one `amp-experiment` element.
+  -->
+  <amp-experiment>
+    <script type="application/json">
+      {
+        "button-color-experiment": {
+          "variants": {
+            "yellow": 30,
+            "red": 30,
+            "blue": 30
+          }
+        }
+      }
+    </script>
+  </amp-experiment>
+<!--
+  An experimental button. The background of the button is going to be yellow for the 30% of users, red for 30% of users, blue for 30% of users and, for the remaining 10% of users, the button background is going to be the default color which is grey in this sample.
+-->
+<button class= "button button-experiment">Click here</button>
+
+<!-- #### Reporting -->
+
+<!--
+  Measure results of the experiment using [amp-pixel](https://github.com/ampproject/amphtml/blob/master/builtins/amp-pixel.md)...
+-->
+<amp-pixel src="https://example.com/track/?xname=button-color-experiment&xvar=VARIANT(button-color-experiment)"></amp-pixel>
+<!--
+... and/or [amp-analytics](https://github.com/ampproject/amphtml/blob/master/extensions/amp-analytics/amp-analytics.md). Allocated variants are available as a URL substitution variable: `VARIANT(name-of-the-experiment)`. You can check the analytics requests in the network tab of the developer tools.
+-->
+<amp-analytics type="googleanalytics" id="analytics">
+  <script type="application/json">
+    {
+      "vars": {
+        "account": "UA-73836974-1"
+      },
+      "requests": {
+        "exp": "${host}/r/collect?t=exp&xid=${experiment}&xvar=${variant}"
+      },
+      "triggers": {
+        "default pageview": {
+          "on": "visible",
+          "request": "pageview",
+          "request": "exp",
+          "vars": {
+            "title": "amp-experiment",
+            "experiment": "button-color-experiment",
+            "variant": "VARIANT(button-color-experiment)"
+          }
+        }
+      }
+    }
+  </script>
+</amp-analytics>
+
+<!-- #### Development Tip -->
+<!--
+  You can force an experiment to be in a specific variant by adding `amp-x-experiment-name` to the AMP page URL. 
+  * <a href="https://ampbyexample.com/components/amp-experiment#amp-x-button-color-experiment=red">#amp-x-button-color-experiment=red</a>
+  * <a href="https://ampbyexample.com/components/amp-experiment#amp-x-button-color-experiment=blue">#amp-x-button-color-experiment=blue</a>
+  * <a href="https://ampbyexample.com/components/amp-experiment#amp-x-button-color-experiment=yellow">#amp-x-button-color-experiment=yellow</a>
+
+-->
+      
+
+</body>
+</html>


### PR DESCRIPTION
This is a sample for [amp-experiment](https://github.com/ampproject/amphtml/blob/master/extensions/amp-experiment/amp-experiment.md).
This does not use the sticky user feature, we can create a different example using it later.
@sebastianbenz PTAL