### PR TITLE
Don't cache amp-live-list updates

### DIFF
--- a/static/sw.js
+++ b/static/sw.js
@@ -88,6 +88,11 @@ function requestAccepts(request, contentType) {
 function ampByExampleHandler(request, values) {
   // for samples show offline page if offline and samples are not cached
   if (requestAccepts(request, 'text/html')) {
+    // never use cached version for AMP CORS requests (e.g. amp-live-list)
+    if (request.url.indexOf("__amp_source_origin" != -1)) {
+      return toolbox.networkOnly(request, values);
+    }
+    // cache or network - whatever is fastest
     return toolbox.fastest(request, values).catch(function() {
         return toolbox.cacheOnly(new Request(config.offlinePage), values);
     });


### PR DESCRIPTION
Our service worker uses a one-behind caching model for all html requests
to the ampbyexample.com domain. This means amp-live-list update requests
are always one-behind as well.