### PR TITLE
Fix Product sample

### DIFF
--- a/src/50_Samples_%26_Templates/Product.html
+++ b/src/50_Samples_%26_Templates/Product.html
@@ -312,7 +312,7 @@ This sample showcases how to build a product page in AMP HTML.
                     "on": "visible",
                     "request": "pageview",
                     "vars": {
-                        "title": "{{title}}"
+                        "title": "Product"
                     }
                 }
             }

--- a/src/json/related_products.json
+++ b/src/json/related_products.json
@@ -1,0 +1,19 @@
+{
+ "items": [
+   {
+     "src": "https://lh3.googleusercontent.com/O00xttgXZHWYdpiWi7K0y7J2kvBMRXwlumBQNLV1853AMtf7MBBMSJ_ug9MDyUxMNjyo",
+     "desc": "Nexus 5x",
+     "url": "https://store.google.com/product/nexus_5x"
+   },
+   {
+     "src": "https://lh3.googleusercontent.com/HUrBSG8GfhgQY6YgeN_K82S_kuocLkf6MbN_LgN521a4K13x9PXlNipHat2pl4Nk76c",
+     "desc": "Nexus 5x Case",
+     "url": "https://store.google.com/product/adopted_case_n5x"
+   },
+   {
+     "src": "https://lh3.googleusercontent.com/ttVsejKSBY5OLLDj38d1YddiBjkvK9BXqIOzIwa7thdWpMoAJzyhdfYixsl0G2Rx_W8",
+     "desc": "Nexus 5x Folio",
+     "url": "https://store.google.com/product/adopted_folio_n6p"
+   }
+ ]
+}


### PR DESCRIPTION
related_products.json got lost in some merge. This is needed by the Product sample to show related articles.
Also, the title was not added to analytics.
@sebastianbenz PTAL