### PR TITLE
Use correct github link for amp-live-list.go file

### DIFF
--- a/src/20_Components/amp-live-list.html
+++ b/src/20_Components/amp-live-list.html
@@ -80,7 +80,7 @@
 
     A `amp-live-list` must contain a list of items below `<div items>`. Each item has a specific id and the `amp-live-list` will look for items with new id. 
 
-    This sample shows an implementation with a server rendering a series of 10 elements, `amp-live-list` will poll the page every 15 seconds. Every time `amp-live-list` polls the page, the server adds a new item to the page. Refer to [server.go](https://github.com/ampproject/amp-by-example/blob/master/server.go) and [amp-live-list.go](https://github.com/ampproject/amp-by-example/blob/master/amplivelist/amp-live-list.go) for implementation details.
+    This sample shows an implementation with a server rendering a series of 10 elements, `amp-live-list` will poll the page every 15 seconds. Every time `amp-live-list` polls the page, the server adds a new item to the page. Refer to [server.go](https://github.com/ampproject/amp-by-example/blob/master/server.go) and [amp-live-list.go](https://github.com/ampproject/amp-by-example/blob/master/backend/amp-live-list.go) for implementation details.
 
     This sample stops after ten updates. If you want to start over, delete cookies from ampbyexample.com or open this page again in an incognito/private tab.
 


### PR DESCRIPTION
After the server refactoring, all the .go files are now under the backend folder. 