### PR TITLE
Don't explicitly add anchors

### DIFF
--- a/tasks/lib/CodeSection.js
+++ b/tasks/lib/CodeSection.js
@@ -72,13 +72,6 @@ module.exports = class CodeSection {
   markedDoc() {
     if (!this.cachedMarkedDoc) {
       this.cachedMarkedDoc = marked(this.doc);
-      // temporary workaround to fix anchor links breaking
-      // links in the text
-      if (this.cachedMarkedDoc.trim().startsWith('<h')) {
-        this.cachedMarkedDoc = '<div class="anchor-trigger">' +
-          this.cachedMarkedDoc +
-          '</div>';
-      }
     }
     return this.cachedMarkedDoc;
   }

--- a/templates/example.html
+++ b/templates/example.html
@@ -34,13 +34,7 @@
       {{#sections}}
       <div class="box ">
         <div class="column doc {{#hideDocOnMobile}}hide-on-mobile{{/hideDocOnMobile}} {{#metadata.hideDoc}}hide{{/metadata.hideDoc}}">
-          {{#markedDoc}}
-          <a id="example{{id}}" class="anchor-target"></a>
-            {{{markedDoc}}}
-          <a href="#example{{id}}" class="anchor">
-            <div class="anchor-img"></div>
-          </a>
-          {{/markedDoc}}
+          {{{markedDoc}}}
           {{#isLastSection}}
           {{#nextExample}}
           <p>


### PR DESCRIPTION
They don't work half of the time and markdown already automatically
inserts tag ids for headings. Fixes #83