### PR TITLE
Corrected the facebook amp-social-share- data param

### DIFF
--- a/src/20_Components/amp-social-share.html
+++ b/src/20_Components/amp-social-share.html
@@ -37,7 +37,7 @@
     <amp-social-share type="email" width="60" height="44"></amp-social-share>
     <amp-social-share type="pinterest" width="60" height="44"></amp-social-share>
     <amp-social-share type="linkedin" width="60" height="44"></amp-social-share>
-    <amp-social-share type="facebook" width="60" height="44" data-attribution=254325784911610></amp-social-share>
+    <amp-social-share type="facebook" width="60" height="44" data-param-app_id="254325784911610"></amp-social-share>
   </div>
 
   <!-- #### Configuration -->


### PR DESCRIPTION
The old`data-attribution=254325784911610` will cause invalid app id when try to share to Facebook