### PR TITLE
Made class name consistent with experiment name.

### DIFF
--- a/src/20_Components/amp-experiment.html
+++ b/src/20_Components/amp-experiment.html
@@ -22,14 +22,14 @@ The  [amp-experiment](https://github.com/ampproject/amphtml/blob/master/extensio
     Style different variants of the experiment by using `body[amp-x-name-of-experiment="nameOfVariant"`].
   -->
   <style amp-custom>
-    body[amp-x-button-color-experiment="yellow"] .button-experiment{
+    body[amp-x-button-color-experiment="yellow"] .button-color-experiment {
       background-color: yellow;
       color: black;
     }
-    body[amp-x-button-color-experiment="red"] .button-experiment{
+    body[amp-x-button-color-experiment="red"] .button-color-experiment {
       background-color: red;
     }
-    body[amp-x-button-color-experiment="blue"] .button-experiment{
+    body[amp-x-button-color-experiment="blue"] .button-color-experiment {
       background-color: blue;
     }
     button {
@@ -61,7 +61,7 @@ The  [amp-experiment](https://github.com/ampproject/amphtml/blob/master/extensio
 <!--
   An experimental button. The background of the button is going to be yellow for the 30% of users, red for 30% of users, blue for 30% of users and, for the remaining 10% of users, the button background is going to be the default color which is grey in this sample.
 -->
-<button class= "button button-experiment">Click here</button>
+<button class= "button button-color-experiment">Click here</button>
 
 <!-- #### Reporting -->
 


### PR DESCRIPTION
Consistently using “button-color-experiment” for class name *and* experiment name instead of an additional “button-experiment” class name.