### PR TITLE
Separate experiments from component names

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,14 +138,13 @@ You can mark samples as drafts if they are still work-in-progress. This means th
 }--->
 ```
 
-#### Experimental Components
+#### Experimental Features
 
-If your sample is using an experimental component, you can add a metadata section (`<!--- ... --->`) with the JSON variables `experiment` and `component`. This will skip its validation and add an experimental note with instructions to your sample:
+If your sample is using one or more experimental features, you can add a metadata section (`<!--- ... --->`) with the JSON variable `experiments` to specify which experiments to enable. This will skip its validation and add an experimental note with instructions to your sample:
 
 ```json
 <!---{
-  "experiment": true,
-  "component": "amp-experimenal-component"
+  "experiments": ["amp-experiment-name", "amp-experiment-another-name"]
 }--->
 ```
 
@@ -208,7 +207,7 @@ Sample specific backend endpoints should be defined in their own file, e.g. for 
 
 You can’t reference external stylesheets when creating samples. AMP by Example provides a [default styling](https://github.com/ampproject/amp-by-example/blob/master/templates/css/styles.css) for common elements (p, h1, h2, h3, a, ...) which you should use. Sample specific styles must live in the head of the document using the tag `<style amp-custom>`. Try to keep the additional CSS for samples to a minimum and use the default styles as often as possible. If you compile a sample via Gulp and run it, the default styling will be applied.
 
-Please note: if you copy code from a sample's code section, you will not get the style that you can see in the preview section. 
+Please note: if you copy code from a sample's code section, you will not get the style that you can see in the preview section.
 
 ## Contributing
 

--- a/spec/compiler/DocumentParserSpec.js
+++ b/spec/compiler/DocumentParserSpec.js
@@ -40,10 +40,8 @@ describe("DocumentParser", function() {
   var COMMENT = '<!--comment-->';
   var LINK = ' <link href="Hello World" />';
   var META = ' <meta href="Hello World" />';
-  var DOCUMENT_METADATA_1 = '<!---{"experiment": true}--->';
-  var DOCUMENT_METADATA_2 = `<!---{
-    "experiment": true,
-    "component": "amp-accordion"
+  var DOCUMENT_METADATA = `<!---{
+    "experiments": ["amp-accordion"]
   }--->`;
   var DOCUMENT_METADATA_INVALID = `<!---{
     experiment: true,
@@ -148,15 +146,9 @@ describe("DocumentParser", function() {
   });
 
   describe("adds metadata to document", function() {
-    it("before comment", function() {
-      var doc = parse(DOCUMENT_METADATA_1, COMMENT, HEAD, TITLE, HEAD_END);
-      expect(doc.metadata.experiment).toEqual(true);
-      expect(doc.sections.length).toEqual(1);
-    });
     it("after comment", function() {
-      var doc = parse(COMMENT, DOCUMENT_METADATA_2, HEAD, TITLE, HEAD_END, BODY, COMMENT, BODY_END);
-      expect(doc.metadata.experiment).toEqual(true);
-      expect(doc.metadata.component).toEqual("amp-accordion");
+      var doc = parse(COMMENT, DOCUMENT_METADATA, HEAD, TITLE, HEAD_END, BODY, COMMENT, BODY_END);
+      expect(doc.metadata.experiments).toEqual(["amp-accordion"]);
       expect(doc.sections.length).toEqual(3);
     });
     it("invalid metadata", function() {
@@ -216,4 +208,3 @@ describe("DocumentParser", function() {
   }
 
 });
-

--- a/src/20_Components/amp-form.html
+++ b/src/20_Components/amp-form.html
@@ -1,6 +1,5 @@
 <!---{
-    "experiment": true,
-    "component": "amp-form",
+    "experiments": ["amp-form", "form-submit"],
     "preview": "default"
   }--->
 <!--

--- a/src/20_Components/amp-fx-flying-carpet.html
+++ b/src/20_Components/amp-fx-flying-carpet.html
@@ -1,6 +1,5 @@
 <!---{
-    "experiment": true,
-    "component": "amp-fx-flying-carpet"
+    "experiments": ["amp-fx-flying-carpet"]
   }--->
 <!--
   #### Introduction
@@ -61,7 +60,7 @@
   <!--
     `amp-fx-flying-carpet` can be used to display ads.
 
-    Use `height` parameter to specify the height of the flying carpets "window".    
+    Use `height` parameter to specify the height of the flying carpets "window".
   -->
 
    <div>
@@ -78,7 +77,7 @@
     </amp-fx-flying-carpet>
     <div class="amp-flying-carpet-text-border">Advertising</div>
   </div>
- 
+
   <!-- -->
     <p>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis venenatis, metus a tristique aliquet, enim nibh efficitur sem, ut iaculis urna justo eu diam. Nullam cursus sapien et sodales posuere. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Suspendisse potenti. Donec vitae ornare risus. Maecenas eleifend ante vel dui laoreet, et porttitor libero rutrum. Nam arcu mi, ullamcorper at risus et, pulvinar ultrices erat. In pellentesque sem vel purus auctor, ut venenatis tellus tristique. Phasellus molestie diam orci, nec gravida turpis bibendum ut. Sed sagittis aliquet lorem sed dictum.

--- a/src/50_Samples_%26_Templates/Hotel.html
+++ b/src/50_Samples_%26_Templates/Hotel.html
@@ -1,9 +1,9 @@
 <!---{
   "preview": "default",
   "draft": true,
-  "experiment": true,
-  "component": "amp-form"
-  }---><!--
+  "experiments": ["amp-form", "form-submit"]
+  }--->
+  <!--
   #### Introduction
 
   This is a sample template for a hotel listing in AMP.

--- a/src/50_Samples_%26_Templates/Housing.html
+++ b/src/50_Samples_%26_Templates/Housing.html
@@ -1,6 +1,5 @@
 <!---{
-    "experiment": true,
-    "component": "amp-form",
+    "experiments": ["amp-form", "form-submit"],
     "default": "preview",
     "preview": "default"
   }--->
@@ -148,7 +147,7 @@ This sample showcases how to build a housing page in AMP HTML. Explore how to us
 
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
     <script async src="https://cdn.ampproject.org/v0.js"></script>
-    </head>     
+    </head>
     <body>
         <h4>
             <!-- #### Title -->
@@ -156,10 +155,10 @@ This sample showcases how to build a housing page in AMP HTML. Explore how to us
             <amp-fit-text width="300" height="45" layout="responsive" max-font-size="45">
                     Cosy House in Central London
             </amp-fit-text>
-        </h4>  
-        <h4 class="price-description">£430,000</h4> 
+        </h4>
+        <h4 class="price-description">£430,000</h4>
         <p id="housing-description">London SW1A 1AA</p>
-          
+
 
         <!-- #### Image Gallery -->
         <!-- The `amp-carousel` works very well for housing image galleries. Learn more about `amp-carousel` [here](/advanced/image_galleries_with_amp-carousel/). -->
@@ -167,10 +166,10 @@ This sample showcases how to build a housing page in AMP HTML. Explore how to us
             <amp-img src="/img/buckingham_palace_building_1280x960.jpg" width="1280" height="960" layout="responsive" alt="Buckingham Palace" attribution="https://pixabay.com"></amp-img>
             <amp-img src="/img/buckingham_palace_entrance_1280x853.jpg" width="1280" height="853" layout="responsive" alt="Buckingham Palace entrance" attribution="https://pixabay.com"></amp-img>
         </amp-carousel>
-        <!-- These buttons are used for requesting details on the property. -->  
+        <!-- These buttons are used for requesting details on the property. -->
         <div class="contact-section">
-            <h4 class="contact-heading"> Do you like this property?</h4> 
-            <div class="contact">       
+            <h4 class="contact-heading"> Do you like this property?</h4>
+            <div class="contact">
                 <a href="tel:012 3456789" class="button button-primary call-to-action">Call agent</a>
                 <a href="mailto:someone@example.com" class="button button-primary call-to-action">Email agent</a>
             </div>
@@ -178,7 +177,7 @@ This sample showcases how to build a housing page in AMP HTML. Explore how to us
 
 
     <!-- #### Social -->
-    <!-- The Social Share extension provides a common interface for share buttons. Learn more about `amp-social-share` [here](/components/amp-social-share/). --> 
+    <!-- The Social Share extension provides a common interface for share buttons. Learn more about `amp-social-share` [here](/components/amp-social-share/). -->
     <p class="social-share">
         <amp-social-share type="twitter"
         width="60"
@@ -226,13 +225,13 @@ This sample showcases how to build a housing page in AMP HTML. Explore how to us
         </section>
         <section>
           <h4>Mortgage Calculator</h4>
-          <form method="post" action="<%host%>/samples_templates/housing/calculate-mortgage" action-xhr="<%host%>/samples_templates/housing/calculate-mortgage-xhr"  target="_top">  
+          <form method="post" action="<%host%>/samples_templates/housing/calculate-mortgage" action-xhr="<%host%>/samples_templates/housing/calculate-mortgage-xhr"  target="_top">
             <div class="form-field">
               <span class="form-field-left">
                 Price
               </span>
               <div class="form-field-right">
-                <span>&#163</span><input type="number" name="price" maxlength="10" value="2000000" required> 
+                <span>&#163</span><input type="number" name="price" maxlength="10" value="2000000" required>
               </div>
             </div>
             <div class="form-field">

--- a/src/50_Samples_%26_Templates/Product.html
+++ b/src/50_Samples_%26_Templates/Product.html
@@ -1,8 +1,7 @@
 <!---{
   "preview": "default",
   "default": "preview",
-  "experiment": true,
-  "component": "amp-form"
+  "experiments": ["amp-form", "form-submit"]
   }--->
 <!--
 #### Introduction

--- a/src/50_Samples_%26_Templates/Product_Listing.html
+++ b/src/50_Samples_%26_Templates/Product_Listing.html
@@ -1,8 +1,7 @@
 <!---{
   "preview": "default",
   "default": "preview",
-  "experiment": true,
-  "component": "amp-form"
+  "experiments": ["amp-form", "form-submit"]
 }--->
 <!--
 #### Introduction

--- a/tasks/compile-example.js
+++ b/tasks/compile-example.js
@@ -182,13 +182,6 @@ module.exports = function(config, updateTimestamp) {
       };
       Metadata.add(args);
 
-      if (document.metadata.experiment && !document.metadata.component) {
-        throw new PluginError({
-          plugin: 'compile-example',
-          message: 'Example (' + file.path + ') is `experiment`: true, but ' +
-            'is missing the `component` metadata'});
-      }
-
       // compile example
       const sampleHtml = pageTemplates.render(config.templates.example, args);
       file.path = path.join(file.base, example.targetPath());
@@ -217,7 +210,7 @@ module.exports = function(config, updateTimestamp) {
           args.a4aEmbedUrl = config.api.host + '/' + example.targetPath();
         }
 
-        // generate prewiew 
+        // generate preview
         args.title = example.title() + ' (Preview) - ' + 'AMP by Example';
         args.desc = "This is a live preview of the '" + example.title() + "' sample. " + args.desc;
         args.canonical = config.host + example.url() + 'preview/';
@@ -267,7 +260,7 @@ module.exports = function(config, updateTimestamp) {
           description: exampleFile.document.description(),
           url: exampleUrl,
           selected: selected,
-          experiment: exampleFile.document.metadata.experiment,
+          experiments: exampleFile.document.metadata.experiments,
           highlight: exampleFile.document.metadata.highlight
         });
       });

--- a/tasks/validate-example.js
+++ b/tasks/validate-example.js
@@ -39,7 +39,7 @@ module.exports = function() {
 
       // skip over experiments which will fail validation
       if (file.metadata &&
-        (file.metadata.experiment || file.metadata.skipValidation)) {
+        (file.metadata.experiments || file.metadata.skipValidation)) {
         gutil.log('Validating ' + file.relative +
           ': ' + gutil.colors.yellow('IGNORED'));
         return callback(null, file);

--- a/templates/css/styles.css
+++ b/templates/css/styles.css
@@ -186,6 +186,10 @@ button, .button {
   width: 160px;
 }
 
+.amp-experiment-list span:not(:last-of-type)::after {
+  content: ", "
+}
+
 .amp-experiment {
   padding-right: 24px;
   background-position: 100% center;
@@ -212,6 +216,7 @@ button, .button {
   url('/img/ic_experiment_black_1x_web_36dp.png') 1x,
   url('/img/ic_experiment_black_2x_web_36dp.png') 2x );
 }
+
 
 /* actions */
 

--- a/templates/example.html
+++ b/templates/example.html
@@ -20,9 +20,9 @@
     {{> header.html}}
     <article>
       <h3 id="title">
-        {{subHeading}} {{#metadata.experiment}}<i class="amp-experiment-large"></i>{{/metadata.experiment}}
+        {{subHeading}} {{#metadata.experiments.length}}<i class="amp-experiment-large"></i>{{/metadata.experiments.length}}
       </h3>
-      {{#metadata.experiment}}
+      {{#metadata.experiments.length}}
       <div class="box">
         <div class="column doc">
           {{> experiment.html}}
@@ -30,7 +30,7 @@
         <div class="column code hide-on-mobile {{#metadata.hideCode}}hide{{/metadata.hideCode}}"></div>
         <div class="column preview hide-on-mobile {{#metadata.hidePreview}}hide{{/metadata.hidePreview}}"></div>
       </div>
-      {{/metadata.experiment}}
+      {{/metadata.experiments.length}}
       {{#sections}}
       <div class="box ">
         <div class="column doc {{#hideDocOnMobile}}hide-on-mobile{{/hideDocOnMobile}} {{#metadata.hideDoc}}hide{{/metadata.hideDoc}}">

--- a/templates/experiment.html
+++ b/templates/experiment.html
@@ -1,9 +1,9 @@
 <div id="experimental-mode" class="card info">
   <h4>Experimental Mode</h4>
-  <p>The <code>{{component}}</code> component is currently in experimental mode and needs to be manually enabled (<a href="https://www.ampproject.org/docs/reference/experimental.html">more info</a>).</p>
+  <p>This example uses the following experimental feature{{#metadata.experiments.1}}s{{/metadata.experiments.1}}: <code class="amp-experiment-list">[{{#metadata.experiments}}<span>{{.}}</span>{{/metadata.experiments}}]</code><br>Enable them below and <a href="https://www.ampproject.org/docs/reference/experimental.html">learn more here</a>.</p>
 
   <div id="experiment-container">
-    <button id="experiment-toggle" class="button-inactive">Enable Experiment</button>
+    <button id="experiment-toggle" class="button-inactive">Enable Experiment{{#metadata.experiments.1}}s{{/metadata.experiments.1}}</button>
     <a id="canary-toggle" class="button button-inactive" href="https://cdn.ampproject.org/experiments.html" target="_blank">Enable Dev Channel</a>
   </div>
 </div>
@@ -17,21 +17,30 @@ document.addEventListener("DOMContentLoaded", function(event) {
       element.className = element.className.replace("inactive", "primary");
     }
 
-    function isExperimentEnabled() {
-      return AMP.isExperimentOn('{{component}}');
+    function areAllExperimentsEnabled() {
+      {{#metadata.experiments}}
+      if (!AMP.isExperimentOn('{{.}}')) {
+        return false;
+      }
+      {{/metadata.experiments}}
+
+      return true;
     }
 
-    function enableExperiment() {
-      if (!isExperimentEnabled()) {
-        AMP.toggleExperiment('{{component}}');
+    function enableExperiments() {
+      {{#metadata.experiments}}
+      if (!AMP.isExperimentOn('{{.}}')) {
+        AMP.toggleExperiment('{{.}}');
       }
+      {{/metadata.experiments}}
+
       location.reload();
     }
 
     // enable active experiment button
-    if (!isExperimentEnabled()) {
+    if (!areAllExperimentsEnabled()) {
       var experimentToggle = document.getElementById("experiment-toggle");
-      experimentToggle.addEventListener("click", enableExperiment);
+      experimentToggle.addEventListener("click", enableExperiments);
       enableButton('experiment-toggle');
     }
 

--- a/templates/preview.html
+++ b/templates/preview.html
@@ -14,12 +14,12 @@
   <body>
     <div id="close-preview">
       <a href=".." id="exit">
-        View annotated Source 
+        View annotated Source
       </a>
     </div>
-      {{#metadata.experiment}}
+      {{#metadata.experiments.length}}
         {{> experiment.html}}
-      {{/metadata.experiment}}
+      {{/metadata.experiments.length}}
     <article id="preview">
       {{#sections}}
       {{{preview}}}


### PR DESCRIPTION
Currently there's an assumption built in that there is a 1:1 relationship between the `component` of a page and the experiment required to properly run it. This breaks the `amp-form` example as it needs both the `amp-form` and `form-submit` experiments enabled to prevent form submission with invalid data.

These changes:
- Add a new "experiments" metadata key to specify the AMP experiments to be enabled for a given page.
- Update the experiment page to enable all specified experiments.
- Update the samples to specify individual experiments required.

Open to discussion on this one, because having the `experiment` and the `experiments` metadata feels a bit redundant, but it makes the makes the mustache a bit cleaner. I was fiddling around trying to just set `experiment` to `true` if `experiments` was set, but `gulp` wasn't cooperating.

@kul3r4 @sebastianbenz please dive in and see what you think.