### PR TITLE
image accessibility, prefix removal on animation

### DIFF
--- a/src/30_Advanced/Image_Galleries_with_amp-carousel.html
+++ b/src/30_Advanced/Image_Galleries_with_amp-carousel.html
@@ -18,7 +18,7 @@
   <!-- We will also be using the amp-fit-text component. -->
   <script async custom-element="amp-fit-text" src="https://cdn.ampproject.org/v0/amp-fit-text-0.1.js"></script>
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <style amp-custom>
     .carousel1, .carousel2 {
@@ -53,18 +53,18 @@
   -->
   <amp-carousel class="carousel1" layout="responsive" height="450" width="500" type="slides">
     <div class="slide">
-      <amp-img src="/img/Border_Collie.jpg" layout="responsive" width="500" height="300"></amp-img>
+      <amp-img src="/img/Border_Collie.jpg" layout="responsive" width="500" height="300" alt="Border Collie"></amp-img>
       <amp-fit-text layout="responsive" width="500" height="150"> The Border Collie is a working and herding dog breed developed in the Anglo-Scottish border region for herding livestock, especially sheep. It was specifically bred for intelligence and obedience.  Considered highly intelligent, and typically extremely energetic, acrobatic, smart and athletic, they frequently compete with great success in dog sports, in addition to their success in sheepdog trials. They are often cited as the most intelligent of all domestic dogs. Border Collies also remain employed throughout the world in their traditional work of herding livestock.  </amp-fit-text>
     </div>
 
     <div class="slide">
       <amp-img src="/img/Shetland_Sheepdog.jpg" layout="responsive" width="500" height="340"></amp-img>
-      <amp-fit-text layout="responsive" width="500" height="110"> The Shetland Sheepdog, often known as the Sheltie, is a breed of herding dog. Less favored nicknames are the Toy Collie and the Miniature Collie. They are small dogs, and come in a variety of colors, such as sable, tri-color, and blue merle. They are very intelligent, vocal, excitable, energetic dogs who are always willing to please and work hard.
+      <amp-fit-text layout="responsive" width="500" height="110" alt="Shetland Sheepdog"> The Shetland Sheepdog, often known as the Sheltie, is a breed of herding dog. Less favored nicknames are the Toy Collie and the Miniature Collie. They are small dogs, and come in a variety of colors, such as sable, tri-color, and blue merle. They are very intelligent, vocal, excitable, energetic dogs who are always willing to please and work hard.
       </amp-fit-text>
     </div>
 
     <div class="slide">
-      <amp-img src="/img/Hovawart.jpg" layout="responsive" width="500" height="350"></amp-img>
+      <amp-img src="/img/Hovawart.jpg" layout="responsive" width="500" height="350" alt="Hovawart"></amp-img>
       <amp-fit-text layout="responsive" width="500" height="100">
 The Hovawart is a medium to large size German dog breed. The name of the breed means "an estate
 guard dog", which is the original use for the breed. The breed originated in the Black Forest
@@ -77,7 +77,7 @@ region and was first described in text and paintings in medieval times.
   <!-- Another carousel with caption, this time the caption overlays the image. -->
   <amp-carousel class="carousel2" layout="responsive" height="400" width="500" type="slides">
     <div class="slide">
-      <amp-img src="/img/Border_Collie.jpg" layout="fill"></amp-img>
+      <amp-img src="/img/Border_Collie.jpg" layout="fill" alt="Border Collie"></amp-img>
       <div class="caption">
 The Border Collie is a working and herding dog breed developed in the Anglo-Scottish border region
 for herding livestock, especially sheep. It was specifically bred for intelligence and obedience.
@@ -85,7 +85,7 @@ for herding livestock, especially sheep. It was specifically bred for intelligen
     </div>
 
     <div class="slide">
-      <amp-img src="/img/Shetland_Sheepdog.jpg" layout="fill"></amp-img>
+      <amp-img src="/img/Shetland_Sheepdog.jpg" layout="fill" alt="Shetland Sheepdog"></amp-img>
       <div class="caption">
 The Shetland Sheepdog, often known as the Sheltie, is a breed of herding dog. Less favored nicknames
 are the Toy Collie and the Miniature Collie. They are small dogs, and come in a variety of colors,
@@ -95,7 +95,7 @@ who are always willing to please and work hard.
     </div>
 
     <div class="slide">
-      <amp-img src="/img/Hovawart.jpg" layout="fill"></amp-img>
+      <amp-img src="/img/Hovawart.jpg" layout="fill" alt="Hovaward"></amp-img>
       <div class="caption">
 The Hovawart is a medium to large size German dog breed. The name of the breed means "an estate guard
 dog", which is the original use for the breed. The breed originated in the Black Forest region and was


### PR DESCRIPTION
Added alt attributes to images.
Remove prefix from animation of -ms- (never supported), -moz- and -o-.
Left -webkit- in for older mobile devices.
