### PR TITLE
remove unneeded animation prefixes

### DIFF
--- a/src/20_Components/amp-img.html
+++ b/src/20_Components/amp-img.html
@@ -11,7 +11,8 @@
   <meta charset="utf-8">
   <link rel="canonical" href="<%host%>/components/amp-img/">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style>
+  <noscript><style amp-boilerplate>body{-webkit-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>
 <body>
@@ -21,14 +22,14 @@
     A simple [responsive](https://www.ampproject.org/docs/guides/responsive/control_layout.html)
     image - *width* and *height* are used to determine the aspect ratio.
   -->
-  <amp-img src="/img/amp.jpg" width="1080" height="610" layout="responsive" alt="an image"></amp-img>
+  <amp-img src="/img/amp.jpg" width="1080" height="610" layout="responsive" alt="image description"></amp-img>
 
   <!--
     Use `srcset` to specify different images for varying viewport widths and pixel densities (change the width of your browser windows to test it).
   -->
   <amp-img src="/img/amp.jpg" srcset="/img/amp.jpg 1080w, /img/amp-900.jpg 900w, /img/amp-800.jpg 800w,
   /img/amp-700.jpg 700w, /img/amp-600.jpg 600w, /img/amp-500.jpg 500w, /img/amp-400.jpg 400w,
-  /img/amp-300.jpg 300w, /img/amp-200.jpg 200w, /img/amp-100.jpg 100w" width="1080" height="610" layout="responsive" alt="an image"></amp-img>
+  /img/amp-300.jpg 300w, /img/amp-200.jpg 200w, /img/amp-100.jpg 100w" width="1080" height="610" layout="responsive" alt="image description"></amp-img>
 
 </body>
 </html>


### PR DESCRIPTION
Removed unused and unneeded browser prefixes. left -webkit- for older android and UC browser. 
updated text of alt attribute to be more descriptive.