### PR TITLE
Updated CSS

### DIFF
--- a/src/20_Components/amp-ad.html
+++ b/src/20_Components/amp-ad.html
@@ -11,7 +11,7 @@
   <meta charset="utf-8">
   <link rel="canonical" href="<%host%>/components/amp-ad/">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start step-end both;animation:-amp-start step-end both;@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <!-- Import the `amp-ad` component in the header. -->
   <script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script>


### PR DESCRIPTION
Removed unneeded prefix versions.
animation: name 0s steps(1,end) 1 0s normal both 
is the equivalent of 
animation: name step-end both
as iteration count defaults to 1, delay defaults to 0s, duration defaults to 0s, and direction defaults to normal. Using the shorthand, you get the defaults for undeclared values. step-end is a shorter way of writing steps(1, end)

left webkit prefix in for android and uc browser.