### PR TITLE
make samples embeddable

### DIFF
--- a/tasks/lib/ExampleFile.js
+++ b/tasks/lib/ExampleFile.js
@@ -101,6 +101,13 @@ class ExampleFile {
     return path.join(this.targetParentDir(), this.targetName(), 'index.html');
   }
 
+  targetEmbedPath() {
+    return path.join(this.targetParentDir(), 
+      this.targetName(), 
+      'embed', 
+      'index.html');
+  }
+
   targetPreviewPath() {
     return path.join(this.targetParentDir(),
         this.targetName(),

--- a/tasks/validate-example.js
+++ b/tasks/validate-example.js
@@ -39,7 +39,8 @@ module.exports = function() {
 
       // skip over experiments which will fail validation
       if (file.metadata &&
-        (file.metadata.experiments || file.metadata.skipValidation)) {
+        (file.metadata.experiments || file.metadata.skipValidation) ||
+         !file.path.endsWith('.html')) {
         gutil.log('Validating ' + file.relative +
           ': ' + gutil.colors.yellow('IGNORED'));
         return callback(null, file);

--- a/templates/css/styles.css
+++ b/templates/css/styles.css
@@ -486,10 +486,8 @@ footer ul li a {
   body {
     background: white;
   }
-  article {
-    margin-top: 56px;
-  }
   article #title {
+    margin-top: 56px;
     padding-bottom: 0px;
   }
   header {

--- a/templates/example.html
+++ b/templates/example.html
@@ -11,6 +11,7 @@
    </style>
   </head>
   {{{bodyTag}}}
+    {{^isEmbed}}
     {{> menu.html}}
     {{#metadata.preview}}
     <a href="preview/" class="fab show-on-mobile">
@@ -18,10 +19,13 @@
     </a>
     {{/metadata.preview}}
     {{> header.html}}
+    {{/isEmbed}}
     <article>
+      {{^isEmbed}}
       <h3 id="title">
         {{subHeading}} {{#metadata.experiments.length}}<i class="amp-experiment-large"></i>{{/metadata.experiments.length}}
       </h3>
+      {{/isEmbed}}
       {{#metadata.experiments.length}}
       <div class="box">
         <div class="column doc">
@@ -35,6 +39,7 @@
       <div class="box ">
         <div class="column doc {{#hideDocOnMobile}}hide-on-mobile{{/hideDocOnMobile}} {{#metadata.hideDoc}}hide{{/metadata.hideDoc}}">
           {{{markedDoc}}}
+          {{^isEmbed}}
           {{#isLastSection}}
           {{#nextExample}}
           <p>
@@ -43,6 +48,7 @@
           </p>
           {{/nextExample}}
           {{/isLastSection}}
+          {{/isEmbed}}
         </div>
         <div class="column code {{#hideCodeOnMobile}}hide-on-mobile{{/hideCodeOnMobile}} {{#metadata.hideCode}}hide{{/metadata.hideCode}}">
           <pre class="hljs"><code class="html">{{{escapedCode}}}</code></pre>
@@ -53,7 +59,9 @@
       </div>
       {{/sections}}
     </article>
+    {{^isEmbed}}
     {{> footer.html}}
+    {{/isEmbed}}
     {{> analytics.html}}
     {{> serviceworker.html}}
   </body>


### PR DESCRIPTION
To make it easier to use samples in an app shell based PWA or a native app.

* strip away menu, title and header.
* append /embed/ to view the embed version of any sample

Also: provide a json sitemap /sitemap.json listing the different categories and samples.