### PR TITLE
Change start_url to index.html to work locally as well

### DIFF
--- a/static/manifest.json
+++ b/static/manifest.json
@@ -2,7 +2,7 @@
   "name": "AMP by Example",
   "short_name": "AMP Examples",
   "description": "Learn AMP by Examples",
-  "start_url": "https://ampbyexample.com",
+  "start_url": "index.html",
   "display": "standalone",
   "background_color": "#607D8B",
   "theme_color": "#607D8B",

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -2,7 +2,7 @@
   "name": "AMP by Example",
   "short_name": "AMP Examples",
   "description": "Learn AMP by Examples",
-  "start_url": "index.html",
+  "start_url": "/index.html",
   "display": "standalone",
   "background_color": "#607D8B",
   "theme_color": "#607D8B",


### PR DESCRIPTION
During local development, if start_url points to https://ampbyexample.com, Chrome will ignore it:

![image](https://cloud.githubusercontent.com/assets/33569/19209256/5a9468e6-8cbb-11e6-8541-91f36b9b810d.png)

The common practice is to only point to [`index.html`](https://developers.google.com/web/updates/2014/11/Support-for-installable-web-apps-with-webapp-manifest-in-chrome-38-for-Android) or [`.`](https://developer.mozilla.org/en-US/docs/Web/Manifest).