### PR TITLE
Fix markup liveblog

### DIFF
--- a/backend/amp-live-list.go
+++ b/backend/amp-live-list.go
@@ -21,6 +21,7 @@ import (
 	"path"
 	"strconv"
 	"time"
+	"log"
 )
 
 const (
@@ -129,7 +130,10 @@ func createPage(newStatus int, timestamp time.Time) Page {
 }
 
 func renderSample(w http.ResponseWriter, r *http.Request, filePath string) {
-	t, _ := template.ParseFiles(filePath)
+	// t := template.New("template test")
+	// t = template.Must(template.ParseFiles(filePath))
+	t, error := template.ParseFiles(filePath)
+	log.Println(error)
 	w.Header().Set("Cache-Control", fmt.Sprintf("max-age=%d, public, must-revalidate", MAX_AGE_IN_SECONDS))
 	newStatus := updateStatus(w, r)
 	t.Execute(w, createPage(newStatus, time.Now()))

--- a/backend/amp-live-list.go
+++ b/backend/amp-live-list.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 	"html/template"
 	"time"
+	"encoding/json"
 )
 
 const (
@@ -82,7 +83,7 @@ type Score struct {
 type Page struct {
 	BlogItems     []BlogItem
 	FootballScore Score
-	BlogMetadata  []BlogPosting
+	BlogMetadata  string
 }
 
 var blogs []BlogItem
@@ -172,7 +173,8 @@ func createPage(newStatus int, timestamp time.Time, r *http.Request) Page {
 	}
 	blogItems := getBlogEntries(newStatus, timestamp)
 	score := createScore(newStatus, 0)
-	return Page{BlogItems: blogItems, FootballScore: score, BlogMetadata: createMetadata(r)}
+	jsonMetadata, _ := json.MarshalIndent(createMetadata(r), "        ", "  ")	
+	return Page{BlogItems: blogItems, FootballScore: score, BlogMetadata: string(jsonMetadata)}
 }
 
 func renderSample(w http.ResponseWriter, r *http.Request, filePath string, t *template.Template) {

--- a/backend/amp-live-list.go
+++ b/backend/amp-live-list.go
@@ -16,7 +16,6 @@ package backend
 
 import (
 	"fmt"
-	"log"
 	"net/http"
 	"path"
 	"strconv"
@@ -112,9 +111,12 @@ func registerHandler(sampleType string, sampleName string) {
 
 	url := path.Join("/", sampleType, sampleName) + "/"
 	filePath := path.Join(DIST_FOLDER, sampleType, sampleName, "index.html")
-
+	t, error := template.ParseFiles(filePath)
+	if error != nil {
+		panic(error)
+	}
 	http.HandleFunc(url, func(w http.ResponseWriter, r *http.Request) {
-		renderSample(w, r, filePath)
+		renderSample(w, r, filePath, t)
 	})
 }
 
@@ -173,9 +175,7 @@ func createPage(newStatus int, timestamp time.Time, r *http.Request) Page {
 	return Page{BlogItems: blogItems, FootballScore: score, BlogMetadata: createMetadata(r)}
 }
 
-func renderSample(w http.ResponseWriter, r *http.Request, filePath string) {
-	t, error := template.ParseFiles(filePath)
-	log.Println(error)
+func renderSample(w http.ResponseWriter, r *http.Request, filePath string, t *template.Template) {
 	w.Header().Set("Cache-Control", fmt.Sprintf("max-age=%d, public, must-revalidate", MAX_AGE_IN_SECONDS))
 	newStatus := updateStatus(w, r)
 	t.Execute(w, createPage(newStatus, time.Now(), r))

--- a/backend/amp-live-list.go
+++ b/backend/amp-live-list.go
@@ -15,13 +15,12 @@
 package backend
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
 	"path"
 	"strconv"
-	"text/template"
+	"html/template"
 	"time"
 )
 
@@ -84,7 +83,7 @@ type Score struct {
 type Page struct {
 	BlogItems     []BlogItem
 	FootballScore Score
-	BlogMetadata  string
+	BlogMetadata  []BlogPosting
 }
 
 var blogs []BlogItem
@@ -171,8 +170,7 @@ func createPage(newStatus int, timestamp time.Time, r *http.Request) Page {
 	}
 	blogItems := getBlogEntries(newStatus, timestamp)
 	score := createScore(newStatus, 0)
-	metadata, _ := json.Marshal(createMetadata(r))
-	return Page{BlogItems: blogItems, FootballScore: score, BlogMetadata: string(metadata)}
+	return Page{BlogItems: blogItems, FootballScore: score, BlogMetadata: createMetadata(r)}
 }
 
 func renderSample(w http.ResponseWriter, r *http.Request, filePath string) {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "gulp-rename": "^1.2.2",
     "gulp-shell": "^0.5.2",
     "gulp-util": "^3.0.7",
-    "highlight.js": "^9.1.0",
+    "highlight.js": "^9.7.0",
     "hogan.js": "^3.0.2",
     "js-beautify": "^1.6.1",
     "marked": "^0.3.5",

--- a/src/50_Samples_%26_Templates/Live_Blog.html
+++ b/src/50_Samples_%26_Templates/Live_Blog.html
@@ -52,20 +52,21 @@ This is a sample template for implementing live blogs in AMP.
           "coverageEndTime": "2016-07-23T16:00:00-07:00",
           "headline": "An AMP Live Blog",
           "description": "A Live Blog implementation with AMP",
-          {{range .BlogItems}}
           "liveBlogUpdate": [
+          {{range $index, $value := .BlogItems}}
+            {{if $index}}, {{end}}
             {
               "@type": "BlogPosting",
-              "headline": "{{.Heading}}",
-              "url": "<%host%>/samples_templates/live_blog/#{{.ID}}",
-              "datePublished": "{{.MetadataTimestamp}}",
+              "headline": "{{$value.Heading}}",
+              "url": "<%host%>/samples_templates/live_blog/#{{$value.ID}}",
+              "datePublished": "{{$value.MetadataTimestamp}}",
               "articleBody": {
-                "@value": "{{.Text}}",
+                "@value": "{{$value.Text}}",
                 "@type": "rdf:HTML"
               }
             }
-          ]
           {{end}}
+          ]
         }
       </script>
       <style amp-custom>

--- a/src/50_Samples_%26_Templates/Live_Blog.html
+++ b/src/50_Samples_%26_Templates/Live_Blog.html
@@ -35,6 +35,7 @@ This is a sample template for implementing live blogs in AMP.
             "@type": "Event",
             "startDate": "2016-07-23T13:00:00-07:00",
             "name": "An AMP Live Blog",
+            "url": "<%host%>/samples_templates/live_blog/",
             "location": {
               "@type": "EventVenue",
               "name": "Chiara Chiappini",
@@ -52,21 +53,7 @@ This is a sample template for implementing live blogs in AMP.
           "coverageEndTime": "2016-07-23T16:00:00-07:00",
           "headline": "An AMP Live Blog",
           "description": "A Live Blog implementation with AMP",
-          "liveBlogUpdate": [
-          {{range $index, $value := .BlogItems}}
-            {{if $index}}, {{end}}
-            {
-              "@type": "BlogPosting",
-              "headline": "{{$value.Heading}}",
-              "url": "<%host%>/samples_templates/live_blog/#{{$value.ID}}",
-              "datePublished": "{{$value.MetadataTimestamp}}",
-              "articleBody": {
-                "@value": "{{$value.Text}}",
-                "@type": "rdf:HTML"
-              }
-            }
-          {{end}}
-          ]
+          "liveBlogUpdate": {{.BlogMetadata}}
         }
       </script>
       <style amp-custom>


### PR DESCRIPTION
Creates metadata from liveBlogUpdate array from the server.
@sebastianbenz PTAL
@jkingyens FYI: This would fix the array problem that was making the metadata unvalid. I also added some of your suggestions from #398 