### PR TITLE
fix server side rendering of meta-data in live blog

### DIFF
--- a/backend/amp-live-list.go
+++ b/backend/amp-live-list.go
@@ -21,7 +21,6 @@ import (
 	"strconv"
 	"html/template"
 	"time"
-	"encoding/json"
 )
 
 const (
@@ -83,7 +82,7 @@ type Score struct {
 type Page struct {
 	BlogItems     []BlogItem
 	FootballScore Score
-	BlogMetadata  string
+	BlogMetadata  []BlogPosting
 }
 
 var blogs []BlogItem
@@ -160,7 +159,7 @@ func createMetadata(r *http.Request) []BlogPosting {
 			blogs[i].MetadataTimestamp,
 			ArticleBody{"Text"},
 			Publisher{"Organization", "AMPByExample",
-				Image{"ImageObject", "https://ampbyexample.com/img/favicon.png", "512", "512"}},
+				Image{"ImageObject", buildSourceOrigin(r.Host) + "/img/favicon.png", "512", "512"}},
 			Image{"ImageObject", blogs[i].Image, "853", "1280"},
 		})
 	}
@@ -173,8 +172,7 @@ func createPage(newStatus int, timestamp time.Time, r *http.Request) Page {
 	}
 	blogItems := getBlogEntries(newStatus, timestamp)
 	score := createScore(newStatus, 0)
-	jsonMetadata, _ := json.MarshalIndent(createMetadata(r), "        ", "  ")	
-	return Page{BlogItems: blogItems, FootballScore: score, BlogMetadata: string(jsonMetadata)}
+	return Page{BlogItems: blogItems, FootballScore: score, BlogMetadata: createMetadata(r)}
 }
 
 func renderSample(w http.ResponseWriter, r *http.Request, filePath string, t *template.Template) {

--- a/src/50_Samples_%26_Templates/Live_Blog.html
+++ b/src/50_Samples_%26_Templates/Live_Blog.html
@@ -42,7 +42,7 @@ This is a sample template for implementing live blogs in AMP.
             "url": "<%host%>/samples_templates/live_blog/",
             "location": {
               "@type": "EventVenue",
-              "name": "Chiara Chiappini",
+              "name": "The Venue Name",
               "address" : {
                 "@type": "PostalAddress",
                 "streetAddress": "701 Mission St",
@@ -62,6 +62,11 @@ This is a sample template for implementing live blogs in AMP.
               "width": "512",
               "height": "512"
             }
+          },
+          "author": {
+            "@type": "Person",
+            "sameAs": "https://github.com/kul3r4",
+            "name": "Chiara Chiappini"
           },
           "image": {
             "@type": "ImageObject",

--- a/src/50_Samples_%26_Templates/Live_Blog.html
+++ b/src/50_Samples_%26_Templates/Live_Blog.html
@@ -72,19 +72,20 @@ This is a sample template for implementing live blogs in AMP.
           "coverageEndTime": "2016-07-23T16:00:00-07:00",
           "headline": "An AMP Live Blog",
           "description": "A Live Blog implementation with AMP",
-          {{range .BlogItems}}
-          "liveBlogUpdate": [ {
+          "liveBlogUpdate": [
+            {{range $index, $value := .BlogItems}}
+            {{if $index}}, {{end}}{
               "@type": "BlogPosting",
-              "headline": "{{.Heading}}",
-              "url": "<%host%>/samples_templates/live_blog/#{{.ID}}",
-              "datePublished": "{{.MetadataTimestamp}}",
+              "headline": "{{$value.Heading}}",
+              "url": "<%host%>/samples_templates/live_blog/#{{$value.ID}}",
+              "datePublished": "{{$value.MetadataTimestamp}}",
               "articleBody": {
-                "@value": "{{.Text}}",
+                "@value": "{{$value.Text}}",
                 "@type": "rdf:text"
               }
-            },
+            }
+            {{end}}
           ]
-          {{end}}
         }
       </script>
       <style amp-custom>

--- a/src/50_Samples_%26_Templates/Live_Blog.html
+++ b/src/50_Samples_%26_Templates/Live_Blog.html
@@ -30,15 +30,19 @@ This is a sample template for implementing live blogs in AMP.
         {
           "@context": "http://schema.org",
           "@type": "LiveBlogPosting",
-          "url": "<%host%>/samples_templates/live_blog/",
+          "url": "https://ampbyexample.com/samples_templates/live_blog/",
+          "articleBody": "This is the initial text in the blog post",
+          "datePublished": "2016-09-08T23:04:28.24337",
           "about": {
             "@type": "Event",
+            "description": "This is my great live blog sample",
             "startDate": "2016-07-23T13:00:00-07:00",
+            "endDate": "2016-07-23T15:00:00-07:00",
             "name": "An AMP Live Blog",
             "location": {
               "@type": "EventVenue",
               "name": "Chiara Chiappini",
-              "address" :{
+              "address" : {
                 "@type": "PostalAddress",
                 "streetAddress": "701 Mission St",
                 "addressLocality": "San Francisco",
@@ -48,24 +52,43 @@ This is a sample template for implementing live blogs in AMP.
               }
             }
           },
+          "publisher": {
+            "@type": "Organization",
+            "name": "Google",
+            "logo": {
+              "@type": "ImageObject",
+              "url": "https://ampbyexample.com/img/favicon.png",
+              "width": "512",
+              "height": "512"
+            }
+          },
+          "image": {
+            "@type": "ImageObject",
+            "url": "https://ampbyexample.com/img/abe_preview.png",
+            "height": "1532",
+            "width": "2046"
+          },
           "coverageStartTime": "2016-07-23T11:30:00-07:00",
           "coverageEndTime": "2016-07-23T16:00:00-07:00",
           "headline": "An AMP Live Blog",
           "description": "A Live Blog implementation with AMP",
-          {{range .BlogItems}}
-          "liveBlogUpdate": [
-            {
+          "liveBlogUpdate": [ {
               "@type": "BlogPosting",
-              "headline": "{{.Heading}}",
-              "url": "<%host%>/samples_templates/live_blog/#{{.ID}}",
-              "datePublished": "{{.MetadataTimestamp}}",
+              "headline": "An AMP Live Blog - just in update #1",
+              "url": "https://ampbyexample.com/samples_templates/live_blog/#post1",
+              "datePublished": "2016-09-08T23:09:28.24337",
               "articleBody": {
-                "@value": "{{.Text}}",
-                "@type": "rdf:HTML"
+                "@value": "It's $14.99 a month. <br> And for a limited time, only $9.99",
+                "@type": "rdf:text"
               }
+            }, {
+              "@type": "BlogPosting",
+              "headline": "An AMP Live Blog - just in update #2",
+              "url": "https://ampbyexample.com/samples_templates/live_blog/#post2",
+              "datePublished": "2016-09-08T23:15:28.24337",
+              "articleBody": "This is a second update to the original post"
             }
           ]
-          {{end}}
         }
       </script>
       <style amp-custom>
@@ -88,7 +111,7 @@ This is a sample template for implementing live blogs in AMP.
         .logo > a {
           font-size: 16px;
           font-weight: 500;
-          color: white;  
+          color: white;
           text-transform: uppercase;
         }
         amp-social-share {
@@ -176,14 +199,14 @@ This is a sample template for implementing live blogs in AMP.
               </amp-img>
               <h4 class="title">{{.Heading}}</h4>
               <p class="date">{{.Date}}</p>
-              <p class="text">{{.Text}}</p>             
+              <p class="text">{{.Text}}</p>
               <p class="social-share">
                 <amp-social-share type="twitter" width="45" height="33" data-param-url="AMPDOC_URL#{{.ID}}"></amp-social-share>
                 <amp-social-share type="facebook" width="45" height="33" data-attribution=254325784911610 data-param-url="AMPDOC_URL#{{.ID}}" ></amp-social-share>
                 <amp-social-share type="gplus" width="45" height="33" data-param-url="AMPDOC_URL#{{.ID}}"></amp-social-share>
                 <amp-social-share type="email" width="45" height="33" data-param-url="AMPDOC_URL#{{.ID}}"></amp-social-share>
                 <amp-social-share type="pinterest" width="45" height="33" data-param-url="AMPDOC_URL#{{.ID}}"></amp-social-share>
-              </p>              
+              </p>
             </div>
           </div>
         {{end}}

--- a/src/50_Samples_%26_Templates/Live_Blog.html
+++ b/src/50_Samples_%26_Templates/Live_Blog.html
@@ -30,7 +30,7 @@ This is a sample template for implementing live blogs in AMP.
         {
           "@context": "http://schema.org",
           "@type": "LiveBlogPosting",
-          "url": "https://ampbyexample.com/samples_templates/live_blog/",
+          "url": "<%host%>/samples_templates/live_blog/",
           "articleBody": "This is the initial text in the blog post",
           "datePublished": "2016-09-08T23:04:28.24337",
           "about": {
@@ -57,14 +57,14 @@ This is a sample template for implementing live blogs in AMP.
             "name": "Google",
             "logo": {
               "@type": "ImageObject",
-              "url": "https://ampbyexample.com/img/favicon.png",
+              "url": "<%host%>/img/favicon.png",
               "width": "512",
               "height": "512"
             }
           },
           "image": {
             "@type": "ImageObject",
-            "url": "https://ampbyexample.com/img/abe_preview.png",
+            "url": "<%host%>/img/abe_preview.png",
             "height": "1532",
             "width": "2046"
           },
@@ -72,23 +72,19 @@ This is a sample template for implementing live blogs in AMP.
           "coverageEndTime": "2016-07-23T16:00:00-07:00",
           "headline": "An AMP Live Blog",
           "description": "A Live Blog implementation with AMP",
+          {{range .BlogItems}}
           "liveBlogUpdate": [ {
               "@type": "BlogPosting",
-              "headline": "An AMP Live Blog - just in update #1",
-              "url": "https://ampbyexample.com/samples_templates/live_blog/#post1",
-              "datePublished": "2016-09-08T23:09:28.24337",
+              "headline": "{{.Heading}}",
+              "url": "<%host%>/samples_templates/live_blog/#{{.ID}}",
+              "datePublished": "{{.MetadataTimestamp}}",
               "articleBody": {
-                "@value": "It's $14.99 a month. <br> And for a limited time, only $9.99",
+                "@value": "{{.Text}}",
                 "@type": "rdf:text"
               }
-            }, {
-              "@type": "BlogPosting",
-              "headline": "An AMP Live Blog - just in update #2",
-              "url": "https://ampbyexample.com/samples_templates/live_blog/#post2",
-              "datePublished": "2016-09-08T23:15:28.24337",
-              "articleBody": "This is a second update to the original post"
-            }
+            },
           ]
+          {{end}}
         }
       </script>
       <style amp-custom>


### PR DESCRIPTION
The live blog sample is rendering some metadata as a string which makes it invalid clientside. This renders the metadata correctly so that it is valid JSON-LD.