### PR TITLE
Fix invalid link to next sample

### DIFF
--- a/tasks/compile-example.js
+++ b/tasks/compile-example.js
@@ -154,7 +154,7 @@ module.exports = function(config, updateTimestamp) {
         return null;
       }
       const metadata = next.document.metadata;
-      if (metadata && metadata.draft) {
+      if (!next.category() || (metadata && metadata.draft)) {
         return findNextExample(examples, index+1);
       }
       return next;


### PR DESCRIPTION
Fixes #422.

This PR adds a metadata field called hideExample that can be used to prevent specific docs from getting picked up in tasks/compile-example.js.  This prevents those documents from appearing the in "Next up" link.