### PR TITLE
Makes the button stay on the right

### DIFF
--- a/src/20_Components/amp-sticky-ad.html
+++ b/src/20_Components/amp-sticky-ad.html
@@ -19,6 +19,11 @@
   <link rel="canonical" href="<%host%>/components/amp-sticky-ad/">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <style amp-custom>
+    .amp-sticky-ad-close-button {
+      min-width: 0;
+    }
+    </style>
 </head>
 <body>
 


### PR DESCRIPTION
This corrects the close button for amp-sticky-add which should always stay on the right.