### PR TITLE
fix testing-tool example link

### DIFF
--- a/src/10_Introduction/How_to_publish_AMPs.html
+++ b/src/10_Introduction/How_to_publish_AMPs.html
@@ -35,7 +35,7 @@ Adding metadata to your AMP files enables third-party sites to better display yo
 
 <amp-img src="/img/carousel_preview_card.png" width="241" height="299"></amp-img>
 
-The [Structured Data Testing Tool](https://developers.google.com/structured-data/testing-tool/) is a great way to test whether the metadata in your AMP files is correct: make sure the “All data” filter shows “AMP Articles” and everything is green. Here is an [example](https://developers.google.com/structured-data/testing-tool?url=https%253A%252F%252Fampbyexample.com%252F).
+The [Structured Data Testing Tool](https://developers.google.com/structured-data/testing-tool/) is a great way to test whether the metadata in your AMP files is correct: make sure the “All data” filter shows “AMP Articles” and everything is green. Here is an [example](https://developers.google.com/structured-data/testing-tool?url=https://ampbyexample.com/).
 
 #### 3. Ensure your AMPs are discoverable
 


### PR DESCRIPTION
Fix the "example" link displayed on the 2nd section of the page: https://ampbyexample.com/introduction/how_to_publish_amps/

<img width="1065" alt="example_link" src="https://cloud.githubusercontent.com/assets/1491664/20459424/8d2cdbcc-ae75-11e6-9280-358ba9c8c301.png"> <br><br>  

Without this patch, the link is redirecting to the testing tool with the host URL html encoded:
<img width="1256" alt="testing_tool_page" src="https://cloud.githubusercontent.com/assets/1491664/20459426/a17756ca-ae75-11e6-9388-782aaef2e1f7.png">
