### PR TITLE
Fixed Social Share example (data-param)

### DIFF
--- a/src/20_Components/amp-social-share.html
+++ b/src/20_Components/amp-social-share.html
@@ -35,7 +35,7 @@
 
   <!-- #### Basic Usage -->
   <!--
-    Embed the [`amp-social-share`](https://www.ampproject.org/docs/reference/components/amp-social-share) widget choosing a share type from the [supported types](https://www.ampproject.org/docs/reference/components/amp-social-share#types), ensuring you use the relevant width and height.
+    Embed the [`amp-social-share`](https://www.ampproject.org/docs/reference/components/amp-social-share) widget choosing a share type from the [supported types](https://www.ampproject.org/docs/reference/components/amp-social-share#types).
 
     `amp-social-share` with `type="facebook"` requires to specify the [facebook app id](https://developers.facebook.com/apps) via `data-attribution`.
   -->
@@ -55,8 +55,9 @@
     * `width`, default 60px.
     * `height`, default 44px.
     * `data-param-text` is the text to include in the share.
-    * `data-param-url` is the URL to share.
+    * `data-param-url` is the URL to share, current URL by default.
     * `data-param-attribution` is where the share is attributed to.
+
 
     All `data-param-*` prefixed attributes will be turned into URL parameters and passed to the share endpoint.
   -->
@@ -70,7 +71,7 @@
 
   <!-- #### Custom Style -->
   <!--
-    Whenever you want to provide your own style, use CSS properties within an `<style amp-custom>` ([Modify the presentation](https://www.ampproject.org/docs/get_started/create/presentation_layout)) element. This will make sure the image stays responsive and centered, and the default styling is overwritten.
+    Whenever you want to provide your own style, use CSS properties within the `<style amp-custom>` element ([Modify the presentation](https://www.ampproject.org/docs/get_started/create/presentation_layout)). This will make sure the image stays responsive and centered, and the default styling is overwritten.
 
     * `background-color`, if you want the element to be a different color.
     * `background-image`, provide another image if you want to change the icon.
@@ -81,11 +82,6 @@
   <amp-social-share type="linkedin"
     width="76"
     height="22"
-    class="custom-style">
-  </amp-social-share>
-  <amp-social-share type="linkedin"
-    width="41"
-    height="64"
     class="custom-style">
   </amp-social-share>
 

--- a/src/20_Components/amp-social-share.html
+++ b/src/20_Components/amp-social-share.html
@@ -32,33 +32,37 @@
     `amp-social-share` with `type="facebook"` requires to specify the [facebook app id](https://developers.facebook.com/apps) via `data-attribution`.
   -->
   <div>
-    <amp-social-share type="twitter" width="60" height="44"> </amp-social-share>
-    <amp-social-share type="gplus" width="60" height="44"></amp-social-share>
-    <amp-social-share type="email" width="60" height="44"></amp-social-share>
-    <amp-social-share type="pinterest" width="60" height="44"></amp-social-share>
-    <amp-social-share type="linkedin" width="60" height="44"></amp-social-share>
-    <amp-social-share type="facebook" width="60" height="44" data-param-app_id="254325784911610"></amp-social-share>
+    <amp-social-share type="twitter"></amp-social-share>
+    <amp-social-share type="gplus"></amp-social-share>
+    <amp-social-share type="email"></amp-social-share>
+    <amp-social-share type="pinterest"></amp-social-share>
+    <amp-social-share type="linkedin"></amp-social-share>
+    <amp-social-share type="facebook" data-param-app_id="254325784911610"></amp-social-share>
   </div>
 
   <!-- #### Configuration -->
   <!--
     Embed the `amp-social-share` widget [choosing a type](https://www.ampproject.org/docs/reference/components/amp-social-share#types), then configure the actions.
 
-    * `text` is the text to include in the share
-    * `url` is the URL to share
-    * `attribution` is where the share is attributed to.
+    * `width`, default 60px.
+    * `height`, default 44px.
+    * `data-param-text` is the text to include in the share.
+    * `data-param-url` is the URL to share.
+    * `data-param-attribution` is where the share is attributed to.
+
+    All `data-param-*` prefixed attributes will be turned into URL parameters and passed to the share endpoint.
   -->
-  <amp-social-share type="linkedin" width="60" height="44"
-    data-text="Check out these AMP Examples!"
-    data-url="https://ampbyexample.com/"
-    data-attribution="AMPhtml">
+  <amp-social-share type="linkedin" width="40" height="40"
+    data-param-text="Check out these AMP Examples!"
+    data-param-url="https://ampbyexample.com/"
+    data-param-attribution="AMPhtml">
   </amp-social-share>
 
   <!-- #### Customized Views -->
   <!--
     Sometimes you want to provide your own style. In this instance, you can **embed an anchor without a `href`** and it will be populated. This provides you the flexibility to build your own UI for the share button.
   -->
-  <amp-social-share type="linkedin" width="60" height="44" data-text="The AMP Project" data-url="https://www.ampproject.org/" data-attribution="amphtml">
+  <amp-social-share type="linkedin">
     <a id="customized-social-share" class="custom">
       <amp-img src="https://raw.githubusercontent.com/google/material-design-icons/master/social/1x_web/ic_share_white_48dp.png" width="18" height="18" layout="responsive" alt="an image">
       </amp-img>

--- a/src/20_Components/amp-social-share.html
+++ b/src/20_Components/amp-social-share.html
@@ -21,7 +21,15 @@
 
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
-
+  <style amp-custom>
+    amp-social-share.custom-style {
+      background-color: #008080;
+      background-image: url('https://raw.githubusercontent.com/google/material-design-icons/master/social/1x_web/ic_share_white_48dp.png');
+      background-repeat: no-repeat;
+      background-position: center;
+      background-size: contain;
+    }
+  </style>
 </head>
 <body>
 
@@ -63,23 +71,22 @@
   <!-- #### Custom Style -->
   <!--
     Whenever you want to provide your own style, use CSS properties within an `<style amp-custom>` ([Modify the presentation](https://www.ampproject.org/docs/get_started/create/presentation_layout)) element. This will make sure the image stays responsive and centered, and the default styling is overwritten.
+
+    * `background-color`, if you want the element to be a different color.
+    * `background-image`, provide another image if you want to change the icon.
+    * `background-repeat` (when using `background-image`), set to `no-repeat`.
+    * `background-position` (when using `background-image`), set to `center`.
+    * `background-size` (when using `background-image`), set to `contain`.
   -->
-  <style amp-custom>
-    amp-social-share[type="linkedin"] {
-      background-color: #008080;
-      background-image: url('https://raw.githubusercontent.com/google/material-design-icons/master/social/1x_web/ic_share_white_48dp.png');
-      background-repeat: no-repeat;
-      background-position: center;
-      background-size: contain;
-    }
-  </style>
   <amp-social-share type="linkedin"
     width="76"
-    height="22">
+    height="22"
+    class="custom-style">
   </amp-social-share>
   <amp-social-share type="linkedin"
     width="41"
-    height="64">
+    height="64"
+    class="custom-style">
   </amp-social-share>
 
 </body>

--- a/src/20_Components/amp-social-share.html
+++ b/src/20_Components/amp-social-share.html
@@ -80,8 +80,6 @@
     * `background-size` (when using `background-image`), set to `contain`.
   -->
   <amp-social-share type="linkedin"
-    width="76"
-    height="22"
     class="custom-style">
   </amp-social-share>
 

--- a/src/20_Components/amp-social-share.html
+++ b/src/20_Components/amp-social-share.html
@@ -52,21 +52,34 @@
 
     All `data-param-*` prefixed attributes will be turned into URL parameters and passed to the share endpoint.
   -->
-  <amp-social-share type="linkedin" width="40" height="40"
+  <amp-social-share type="linkedin"
+    width="40"
+    height="40"
     data-param-text="Check out these AMP Examples!"
     data-param-url="https://ampbyexample.com/"
     data-param-attribution="AMPhtml">
   </amp-social-share>
 
-  <!-- #### Customized Views -->
+  <!-- #### Custom Style -->
   <!--
-    Sometimes you want to provide your own style. In this instance, you can **embed an anchor without a `href`** and it will be populated. This provides you the flexibility to build your own UI for the share button.
+    Whenever you want to provide your own style, use CSS properties within an `<style amp-custom>` ([Modify the presentation](https://www.ampproject.org/docs/get_started/create/presentation_layout)) element. This will make sure the image stays responsive and centered, and the default styling is overwritten.
   -->
-  <amp-social-share type="linkedin">
-    <a id="customized-social-share" class="custom">
-      <amp-img src="https://raw.githubusercontent.com/google/material-design-icons/master/social/1x_web/ic_share_white_48dp.png" width="18" height="18" layout="responsive" alt="an image">
-      </amp-img>
-    </a>
+  <style amp-custom>
+    amp-social-share[type="linkedin"] {
+      background-color: #008080;
+      background-image: url('https://raw.githubusercontent.com/google/material-design-icons/master/social/1x_web/ic_share_white_48dp.png');
+      background-repeat: no-repeat;
+      background-position: center;
+      background-size: contain;
+    }
+  </style>
+  <amp-social-share type="linkedin"
+    width="76"
+    height="22">
+  </amp-social-share>
+  <amp-social-share type="linkedin"
+    width="41"
+    height="64">
   </amp-social-share>
 
 </body>


### PR DESCRIPTION
I also cleaned it up on several places, there is no need for a width=60 if the default is 60px for example (maybe at the time this example was created there was no default?). Displaying less attributes makes the examples easier to read, especially if they aren't needed for a particular example.

The Basic Usage is a lot simpler this way, ready to go.

The Configuration paragraph now clearly tells the viewer that "text" is the same as the attribute, and I've fixed the data-attributes, because they're (now) supposed to be "data-param-*".

I've started cleaning up the "Customized Views", just stripping away the configuration that isn't needed in this example for now (the example looked quite scary with about 10-15 tags and attributes.). The example bugs out on my screen, so I'm thinking this example is deprecated.