### PR TITLE
Autoplay examples for amp-video and amp-youtube

### DIFF
--- a/src/20_Components/amp-video.html
+++ b/src/20_Components/amp-video.html
@@ -21,7 +21,7 @@
 
   <!-- #### Basic Usage -->
   <!--
-    A simple video with controller. 
+    A simple video with controller.
     `amp-video` supports the following formats: mp4, webm, ogg together with all the formats
     supported by the HTML5 video tag including HLS.
     Boolean attribute (`controls` in this case) must be without values.
@@ -37,14 +37,24 @@
     <source type="video/mp4" src="/video/tokyo.mp4">
     <source type="video/webm" src="/video/tokyo.webm">
   </amp-video>
-  
+
+  <!-- #### Autoplay -->
   <!--
-    Setting `autoplay` and `muted` will enable play video as soon as it get loaded in mute mode.
+    Setting `autoplay` will automatically play/pause the video as it is
+    scrolled into/out of view on supported browsers.
+
+    The video is automatically muted before autoplay starts, when the user
+    taps the video, the video is unmuted.
+
+    If the user has interacted with the video
+    (e.g., mutes/unmutes, pauses/resumes, etc.), and the video is scrolled in
+    or out of view, the state of the video remains as how the user left it.
   -->
   <amp-video width=480 height=270 src="/video/tokyo.mp4"
              poster="/img/tokyo.jpg"
              layout="responsive"
-             autoplay muted loop>
+             controls
+             autoplay>
     <div fallback>
       <p>Your browser doesn't support HTML5 video.</p>
     </div>

--- a/src/20_Components/amp-youtube.html
+++ b/src/20_Components/amp-youtube.html
@@ -25,5 +25,23 @@
                            data-videoid="lBTCB7yLs8Y" >
   </amp-youtube>
 
+  <!-- #### Autoplay -->
+  <!--
+    Setting `autoplay` will automatically play/pause the YouTube video as it is
+    scrolled into/out of view on supported browsers.
+
+    The YouTube video is automatically muted before autoplay starts, when the
+    user taps the video, the video is unmuted.
+
+    If the user has interacted with the YouTube video
+    (e.g., mutes/unmutes, pauses/resumes, etc.), and the video is scrolled in
+    or out of view, the state of the video remains as how the user left it.
+  -->
+  <amp-youtube width="480" height="270"
+                           layout=responsive
+                           data-videoid="lBTCB7yLs8Y"
+                           autoplay >
+  </amp-youtube>
+
 </body>
 </html>


### PR DESCRIPTION
Updates the `amp-video` and `amp-youtube` examples to include highlighted `autoplay` examples and descriptions of the `autoplay` behaviour. 

Part of https://github.com/ampproject/amphtml/issues/4154