### PR TITLE
Move amp-sidebar and amp-app-banner after body

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -302,6 +302,11 @@ gulp.task('test', function() {
       .pipe(jasmine());
 });
 
+gulp.task('test2', function() {
+  return gulp.src('spec/**/*Spec.js')
+      .pipe(jasmine({includeStackTrace: true}));
+});
+
 gulp.task('lint', function() {
   const hasFixFlag = argv.fix;
   let errorsFound = false;

--- a/spec/compiler/ElementSortingSpec.js
+++ b/spec/compiler/ElementSortingSpec.js
@@ -1,0 +1,112 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+describe('ElementSorting', function() {
+
+  const CodeSection = require('../../tasks/lib/CodeSection');
+  const Document = require('../../tasks/lib/Document');
+  const elementSorting = require('../../tasks/lib/ElementSorting');
+
+  const body = '<body><div></div>';
+  const appBanner = '<amp-app-banner><child></child></amp-app-banner>';
+  const sidebar = '<amp-sidebar><child></child></amp-sidebar>';
+  const nestedAppBanner = '<div>' + appBanner + '</div>';
+
+  const multiLineBody = '\n<body>\n<div></div>';
+  const multiLineSidebar = '\n<amp-sidebar>\n<child>\n\n</child></amp-sidebar>';
+  const sidebarWithAttribute = '<amp-sidebar id="menu"><child></child></amp-sidebar>';
+
+  beforeEach(function() {
+    doc = new Document();
+  });
+
+  describe('amp-app-banner', function(){
+    it('removes amp-app-banner', function() {
+      const sectionWithAppBanner = addSection(appBanner);
+      elementSorting.apply(doc);
+      expect(sectionWithAppBanner.preview).toBe('');
+    });
+
+    it('removes nested amp-app-banner', function() {
+      const sectionWithAppBanner = addSection(nestedAppBanner);
+      elementSorting.apply(doc);
+      expect(sectionWithAppBanner.preview).toBe('<div></div>');
+    });
+
+    it('appends amp-app-banner after body', function() {
+      addSection(body);
+      addSection(nestedAppBanner);
+      elementSorting.apply(doc);
+      expect(doc.elementsAfterBody).toBe(appBanner);
+    });
+  });
+
+  describe('amp-sidebar', function(){
+    it('removes amp-sidebar', function() {
+      const sectionWithSidebar = addSection(sidebar);
+      elementSorting.apply(doc);
+      expect(sectionWithSidebar.preview).toBe('');
+    });
+    it('appends amp-sidebar after body', function() {
+      addSection(body);
+      addSection(sidebar);
+      elementSorting.apply(doc);
+      expect(doc.elementsAfterBody).toBe(sidebar);
+    });
+  });
+
+  describe('parsing matches', function(){
+    it('body with multiple lines', function() {
+      addSection(multiLineBody);
+      addSection(sidebar);
+      elementSorting.apply(doc);
+      expect(strip(doc.elementsAfterBody)).toBe(sidebar);
+    });
+    it('element with multiple lines', function() {
+      addSection(body);
+      addSection(multiLineSidebar);
+      elementSorting.apply(doc);
+      expect(strip(doc.elementsAfterBody)).toBe(strip(multiLineSidebar));
+    });
+    it('element with attributes', function() {
+      addSection(body);
+      addSection(sidebarWithAttribute);
+      elementSorting.apply(doc);
+      expect(doc.elementsAfterBody).toBe(sidebarWithAttribute);
+    });
+  });
+
+  it('places sidebar directly after body', function() {
+    const bodySection = addSection(body);
+    const sectionWithSidebar = addSection(sidebar);
+    const sectionWithAppBanner = addSection(appBanner);
+    elementSorting.apply(doc);
+    expect(doc.elementsAfterBody).toBe(sidebar + appBanner);
+  });
+
+  function strip(string) {
+    return string.replace(/\n/g, '');
+  }
+
+  function addSection(string) {
+    const cs = new CodeSection();
+    cs.preview = string;
+    doc.addSection(cs);
+    return cs;
+  };
+
+});
+

--- a/src/20_Components/amp-app-banner.html
+++ b/src/20_Components/amp-app-banner.html
@@ -1,6 +1,3 @@
-<!---{
-    "skipValidation": true
-  }--->
 <!--
   #### Introduction
 

--- a/tasks/compile-example.js
+++ b/tasks/compile-example.js
@@ -182,6 +182,7 @@ module.exports = function(config, updateTimestamp) {
         categories: mapToCategories(examples, example),
         component: document.metadata.component,
         bodyTag: document.body,
+        elementsAfterBody: document.elementsAfterBody,
         sections: document.sections,
         metadata: document.metadata,
         nextExample: nextExample,

--- a/tasks/lib/Document.js
+++ b/tasks/lib/Document.js
@@ -31,6 +31,7 @@ module.exports = class Document {
     this.title = '';
     this.metadata = {};
     this.body = '';
+    this.elementsAfterBody = '';
   }
 
   addSection(section) {

--- a/tasks/lib/DocumentParser.js
+++ b/tasks/lib/DocumentParser.js
@@ -18,6 +18,7 @@
 
 const CodeSection = require('./CodeSection');
 const Document = require('./Document');
+const elementSorting = require('./ElementSorting');
 const beautifyHtml = require('js-beautify').html;
 
 const SINGLE_LINE_TAGS = ['link', 'meta', '!doctype'];
@@ -45,6 +46,7 @@ module.exports.parse = function(input) {
   input = beautifyHtml(input, BEAUTIFY_OPTIONS);
   const parsing = new DocumentParser(input.split('\n'));
   parsing.execute();
+  elementSorting.apply(parsing.document);
   return parsing.document;
 };
 

--- a/tasks/lib/ElementSorting.js
+++ b/tasks/lib/ElementSorting.js
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+"use strict";
+
+// the order is important: amp-sidebar must come directly after the body
+const ELEMENTS_TO_MOVE = ['amp-sidebar', 'amp-app-banner'].map(e => matchHtmlTag(e));
+
+// we're using regex to match the XML tags as we might have to handle 
+// incomplete html tags, which DOM parsers such as cheerio automatically
+// fix when serializing.
+function matchHtmlTag(tagName) {
+  return new RegExp('<' + tagName + '(\\s(.|\\n)*)?>(.|\\n)+<\\/' + tagName + '>', 'im');
+}
+
+/*
+ * Extracts amp-app-banner and amp-sidebar from the document's preview sections.
+ * The extracted sections will be added to a separate field in the document.
+ */
+class ElementSorting {
+
+  apply(doc) {
+    ELEMENTS_TO_MOVE.forEach((matcher) => {
+      const element = this._extract(doc.sections, matcher);
+      if (element) {
+        doc.elementsAfterBody += element;
+      }
+    });
+  }
+
+  _extract(codeSections, regExp) {
+    for (let section of codeSections) {
+      const preview = section.preview;
+      const match = regExp.exec(preview);
+      if (!match) {
+        continue;
+      }
+      const banner = match[0];
+      const prefix = preview.substr(0, match.index);
+      const postfix = preview.substr(match.index + banner.length, preview.length);
+      section.preview = prefix + postfix;
+      return banner;
+    }
+    return null;
+  }
+
+}
+
+module.exports = new ElementSorting();

--- a/templates/example.html
+++ b/templates/example.html
@@ -11,6 +11,7 @@
    </style>
   </head>
   {{{bodyTag}}}
+  {{{elementsAfterBody}}}
     {{^isEmbed}}
     {{> menu.html}}
     {{#metadata.preview}}


### PR DESCRIPTION
After the document has been extraced, move amp-sidebar and
amp-app-banner directly after the body tag. This avoids all
validation errors related to the respective element positioning.