### PR TITLE
Fix runtime errors in amp-banner-sample

### DIFF
--- a/src/20_Components/amp-app-banner.html
+++ b/src/20_Components/amp-app-banner.html
@@ -1,3 +1,9 @@
+<!---
+  {
+    "comment": "Don't install serviceworker as canonical domain is different that serviceworker domain", 
+    "skipServiceWorker": true
+  }
+--->
 <!--
   #### Introduction
 

--- a/tasks/compile-example.js
+++ b/tasks/compile-example.js
@@ -191,7 +191,7 @@ module.exports = function(config, updateTimestamp) {
         includesAnalytics: document.importsComponent('amp-analytics'),
         includesAccordion: document.importsComponent('amp-accordion'),
         includesSidebar: document.importsComponent('amp-sidebar'),
-        includesServiceWorker: document.importsComponent('amp-install-serviceworker')
+        includesServiceWorker: document.importsComponent('amp-install-serviceworker') || document.metadata.skipServiceWorker
       };
       Metadata.add(args);
 


### PR DESCRIPTION
Don't install serviceworker as canonical domain does not match
serviceworker domain.