### PR TITLE
Fix CORS access via www.ampbyexample.com

### DIFF
--- a/backend/amp-form.go
+++ b/backend/amp-form.go
@@ -50,15 +50,6 @@ func submitFormXHRInputText(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte(response))
 }
 
-func submitFormInputText(w http.ResponseWriter, r *http.Request) {
-	name := r.FormValue("name")
-	if isUserTryingTheInputTextErrorDemo(name) {
-		http.Redirect(w, r, fmt.Sprintf("%s/amp-form-input-text-error/", buildSourceOrigin(r.Host)), http.StatusSeeOther)
-	} else {
-		http.Redirect(w, r, fmt.Sprintf("%s/amp-form-input-text-success/", buildSourceOrigin(r.Host)), http.StatusSeeOther)
-	}
-}
-
 func submitFormXHR(w http.ResponseWriter, r *http.Request) {
 	EnableCors(w, r)
 	SetContentTypeJson(w)
@@ -67,7 +58,7 @@ func submitFormXHR(w http.ResponseWriter, r *http.Request) {
 }
 
 func submitForm(w http.ResponseWriter, r *http.Request) {
-	http.Redirect(w, r, fmt.Sprintf("%s/amp-form-success/", buildSourceOrigin(r.Host)), http.StatusSeeOther)
+	http.Redirect(w, r, "/amp-form-success/", http.StatusSeeOther)
 }
 
 func isUserTryingInpuTextDemo(name string) bool {

--- a/backend/request.go
+++ b/backend/request.go
@@ -39,22 +39,13 @@ func isFormPostRequest(method string, w http.ResponseWriter) bool {
 	return true
 }
 
-func buildSourceOrigin(host string) string {
-	if strings.HasPrefix(host, "localhost") {
-		return "http://" + host
-	} else {
-		return "https://" + host
-	}
-}
-
 func EnableCors(w http.ResponseWriter, r *http.Request) {
 	if origin := r.Header.Get("Origin"); origin != "" {
-		sourceOrigin := buildSourceOrigin(r.Host)
 		w.Header().Set("Access-Control-Allow-Origin", origin)
 		w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS")
 		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token")
 		w.Header().Set("Access-Control-Expose-Headers", "AMP-Access-Control-Allow-Source-Origin")
-		w.Header().Set("AMP-Access-Control-Allow-Source-Origin", sourceOrigin)
+		w.Header().Set("AMP-Access-Control-Allow-Source-Origin", origin)
 		w.Header().Set("Access-Control-Allow-Credentials", "true")
 	}
 }


### PR DESCRIPTION
This also removes the buildSourceOrigin helper method which is no longer
needed (using the origin header is usually a better choice).

Fixes #538