### PR TITLE
Include the amp-video script

### DIFF
--- a/src/20_Components/amp-video.html
+++ b/src/20_Components/amp-video.html
@@ -10,8 +10,9 @@
   <meta charset="utf-8">
   <!-- #### Setup -->
   <!--
-    `amp-video` is builtin custom tag and is automatically imported via the AMP runtime.
+    Import the `amp-video` component.
   -->
+  <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <link rel="canonical" href="<%host%>/components/amp-video/">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">

--- a/src/30_Advanced/Integrating_Videos_in_AMP%3A_an_Overview.html
+++ b/src/30_Advanced/Integrating_Videos_in_AMP%3A_an_Overview.html
@@ -4,7 +4,7 @@
 <!--
   #### Introduction
 
-  There many different ways to integrate videos in AMP HTML files. 
+  There many different ways to integrate videos in AMP HTML files.
   Here is a list of all currently supported video formats and platforms.
 -->
 <!-- -->
@@ -24,8 +24,9 @@
   <script async custom-element="amp-dailymotion" src="https://cdn.ampproject.org/v0/amp-dailymotion-0.1.js"></script>
   <script async custom-element="amp-twitter" src="https://cdn.ampproject.org/v0/amp-twitter-0.1.js"></script>
   <script async custom-element="amp-facebook" src="https://cdn.ampproject.org/v0/amp-facebook-0.1.js"></script>
-  <script async custom-element="amp-brightcove" src="https://cdn.ampproject.org/v0/amp-brightcove-0.1.js"></script>  
+  <script async custom-element="amp-brightcove" src="https://cdn.ampproject.org/v0/amp-brightcove-0.1.js"></script>
   <script async custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js"></script>
+  <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <link rel="canonical" href="<%host%>/advanced/integrating_videos_in_amp_an_overview/">
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
@@ -49,7 +50,7 @@
   </amp-video>
   <!-- #### Supported Video Platforms -->
   <!-- ##### amp-brightcove -->
-  <!-- 
+  <!--
     Use `amp-brightcove` for Brightcove videos.
     Find more examples [here](/components/amp-brightcove/).
   -->
@@ -71,7 +72,7 @@
     width="480" height="270">
   </amp-dailymotion>
   <!-- ##### amp-facebook -->
-  <!-- 
+  <!--
     Use `amp-facebook` for Facebook videos.
     Find more examples [here](/components/amp-facebook/).
   -->
@@ -92,7 +93,7 @@
       layout="responsive">
   </amp-instagram>
   <!-- ##### amp-twitter -->
-  <!-- 
+  <!--
     Use `amp-twitter` for Twitter videos.
     Find more examples [here](/components/amp-twitter/).
   -->
@@ -129,7 +130,7 @@
                            data-videoid="lBTCB7yLs8Y" >
   </amp-youtube>
   <!-- #### What if your Video Provider is not Supported?-->
-  <!-- 
+  <!--
     Use `amp-iframe` for videos not supported in AMP.
     Find more examples [here](/components/amp-iframe/).
   -->

--- a/src/30_Advanced/Video_Carousels_with_amp-carousel.html
+++ b/src/30_Advanced/Video_Carousels_with_amp-carousel.html
@@ -20,11 +20,12 @@
   <script async custom-element="amp-dailymotion" src="https://cdn.ampproject.org/v0/amp-dailymotion-0.1.js"></script>
   <script async custom-element="amp-twitter" src="https://cdn.ampproject.org/v0/amp-twitter-0.1.js"></script>
   <script async custom-element="amp-facebook" src="https://cdn.ampproject.org/v0/amp-facebook-0.1.js"></script>
-  <script async custom-element="amp-brightcove" src="https://cdn.ampproject.org/v0/amp-brightcove-0.1.js"></script>  
-  <script async custom-element="amp-brid-player" src="https://cdn.ampproject.org/v0/amp-brid-player-0.1.js"></script> 
-  <script async custom-element="amp-reach-player" src="https://cdn.ampproject.org/v0/amp-reach-player-0.1.js"></script> 
-  <script async custom-element="amp-springboard-player" src="https://cdn.ampproject.org/v0/amp-springboard-player-0.1.js"></script> 
+  <script async custom-element="amp-brightcove" src="https://cdn.ampproject.org/v0/amp-brightcove-0.1.js"></script>
+  <script async custom-element="amp-brid-player" src="https://cdn.ampproject.org/v0/amp-brid-player-0.1.js"></script>
+  <script async custom-element="amp-reach-player" src="https://cdn.ampproject.org/v0/amp-reach-player-0.1.js"></script>
+  <script async custom-element="amp-springboard-player" src="https://cdn.ampproject.org/v0/amp-springboard-player-0.1.js"></script>
   <script async custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js"></script>
+  <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <link rel="canonical" href="<%host%>/advanced/video_carousels_with_amp-carousel/">
@@ -46,7 +47,7 @@
 </head>
 <body>
   <!-- #### The Video Carousel -->
-  <!-- Display a list of videos as slides. For more info about `amp-carousel` take a look [here](/components/amp-carousel/). 
+  <!-- Display a list of videos as slides. For more info about `amp-carousel` take a look [here](/components/amp-carousel/).
   Each AMP video component specifies the aspect ratio using the width and height attributes while the responsive layout takes care of filling the carousel. Some video components are not centered by default in the carousel, we use a CSS flex layout to fix this. -->
   <amp-carousel width="450"
   height="450"
@@ -57,7 +58,7 @@
         <p>Your browser doesn't support HTML5 video.</p>
       </div>
     </amp-video>
-    <amp-brid-player data-partner="264" data-player="4144" data-video="13663" 
+    <amp-brid-player data-partner="264" data-player="4144" data-video="13663"
       layout="responsive" width="480" height="270"></amp-brid-player>
     <amp-brightcove data-account="906043040001" data-video-id="1401169490001" data-player-id="180a5658-8be8-4f33-8eba-d562ab41b40c"
       layout="responsive" width="400" height="300">
@@ -75,7 +76,7 @@
       <div class="amp-video-container">
         <amp-reach-player class="amp-video" data-embed-id="default" layout="responsive" width="560" height="315"></amp-reach-player>
       </div>
-    </div>   
+    </div>
     <amp-springboard-player data-site-id="261" data-mode="video" data-content-id="1578473"
       data-player-id="test401" data-domain="test.com" data-items="10"
       layout="responsive" width="480" height="270">
@@ -87,7 +88,7 @@
     <amp-iframe width="400" height="300" layout="responsive" sandbox="allow-scripts allow-same-origin allow-popups"
       allowfullscreen frameborder="0"
       src="https://player.ooyala.com/iframe.html?ec=Vxc2k0MDE6Y_C7J5podo3UDxlFxGaZrQ&pbid=6440813504804d76ba35c8c787a4b33c&platform=html5" >
-    </amp-iframe>                      
+    </amp-iframe>
   </amp-carousel>
 </body>
 </html>


### PR DESCRIPTION
amp-video is no longer a built-in (although it works without the script for backward compatibility). this PR adds the amp-video scripts to ABE pages that use it.