### PR TITLE
Improve docs for the poll sample

### DIFF
--- a/src/50_Samples_%26_Templates/Poll.html
+++ b/src/50_Samples_%26_Templates/Poll.html
@@ -83,16 +83,21 @@ Import the additional AMP components. This sample uses a amp-form and mustache t
 <h4 id="header1">Flightless bird poll</h4>
 <!-- #### Poll -->
 <!--
-We use `amp-form` to implement a poll. To avoid multiple votes by the same user, we need to identify which users already voted.
-We use a cookie called `POLL_USER_ID` to identify the user.
-Given in Safari the default behavior is to block third-party cookies from sites that have not been previously visited, this approach may not work if the page is visited via the AMP Cache. In this case we fallback to checking for duplicate entries via the `CLIENT_ID`.
-The `CLIENT_ID` is an unique identifier for the user when
-accessing a specific origin, for example the original page or the cached version of it, this means that the same user will generate two different
-values when accessing different origins. That's why we use a custom cookie to track cross origin access to the poll page.
-The `CLIENT_ID` variable can be passed via an amp-form by declaring an hidden input
-value with `default-value="CLIENT_ID(POLL_USER_ID)`. In our implementation, the backend sets `POLL_USER_ID` to the value of `CLIENT_ID`, but the value of this cookie is not relevant and you could re-use your own session id.
-Read more about variable substitution [here](https://github.com/ampproject/amphtml/blob/ab78ba87cbf0408ca0ddcfcba7e666e1c1152051/extensions/amp-form/amp-form.md#variable-substitutions).
-Currently, HTML tables are not supported in form responses, that's why we use CSS to layout the result data. -->
+We use `amp-form` to implement a poll. To avoid multiple votes by the same user, we need to identify which users have
+already voted. We use a cookie called `POLL_USER_ID` to identify the user. Given that in Safari the default behavior is
+to block third-party cookies from sites that have not been previously visited, this approach may not work if the page
+is visited via the AMP Cache. In this case we fallback to checking for duplicate entries via the `CLIENT_ID`.
+
+The `CLIENT_ID` is a unique identifier for the user when accessing a specific origin, for example the original page or
+the cached version of it. This means that the same user will generate two different values when accessing different origins.
+That's why we use a custom cookie to track cross origin access to the poll page.
+
+The `CLIENT_ID` variable can be passed via an amp-form by declaring a hidden input value with
+`default-value="CLIENT_ID(POLL_USER_ID)`. In our implementation, the backend sets `POLL_USER_ID` to the value of `CLIENT_ID`,
+but the value of this cookie is not relevant and you could re-use your own session id.
+
+Read more about [variable substitution](https://www.ampproject.org/docs/reference/components/amp-form#variable-substitutions).
+Currently, HTML tables are not supported in form responses, so we'll use CSS to layout the result data. -->
 
 <form method="post" action-xhr="<%host%>/samples_templates/poll/submit" target="_blank"
       id="poll1"
@@ -102,6 +107,12 @@ Currently, HTML tables are not supported in form responses, that's why we use CS
         <p>What is your favorite flightless bird?</p>
         <p>Choose your favourite flightless bird and you will discover what other users have chosen.
         If you have already voted, your answer will be overwritten.</p>
+
+<!-- #### Submit form on input change -->
+<!--
+In order to submit the form as soon as the user picks an option, we will add an
+[`on` attribute](https://www.ampproject.org/docs/reference/spec#on) to each `<input>`, that will submit the poll on change.
+-->
         <ul>
           [[range $key, $value := .Questions]]
           <li>


### PR DESCRIPTION
Note that I wasn't able to run the sample with gulp backend:serve because Go couldn't find the `golang.org/x/net/context` import in $GOPATH (which is empty on my machine). We might need to add to the [Running the backend](https://github.com/ampproject/amp-by-example#running-the-backend-server) instructions. Two other packages weren't found: `google.golang.org/appengine` and `google.golang.org/appengine/datastore`.