### PR TITLE
Fix sample formatting in playground

### DIFF
--- a/src/20_Components/amp-fit-text.html
+++ b/src/20_Components/amp-fit-text.html
@@ -18,7 +18,6 @@
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <style amp-custom>
     div.fixedblock { 
-      display: inline-block;
       margin: 8px 0;
       height: 200px;
       width:  200px;

--- a/src/20_Components/amp-form.html
+++ b/src/20_Components/amp-form.html
@@ -47,6 +47,9 @@
   .other-input {
     margin: 0 16px;
   }
+  form {
+    margin: 16px;
+  }
   </style>
 </head>
 <body>

--- a/src/20_Components/amp-selector.html
+++ b/src/20_Components/amp-selector.html
@@ -41,6 +41,10 @@ amp-selector {
   margin: 0 16px;
   height: 40px;
 }
+amp-selector li {
+  line-height: 24px;
+  margin: 8px;
+}
 </style>
 </head>
 <body>

--- a/templates/css/styles.css
+++ b/templates/css/styles.css
@@ -672,7 +672,7 @@ input[type=text], input[type=email], input[type=date] {
   border: none;
   border-bottom: 1px solid rgba(0,0,0,.12);
   font-size: 16px;
-  margin-bottom: 16px;
+  margin-bottom: 8px;
   padding: 4px 0;
   background: 0 0;
   color: inherit;

--- a/templates/header.html
+++ b/templates/header.html
@@ -5,10 +5,12 @@
   <a id="logo" href="/"></a>
   <div id="actions">
     {{#urlSource}}
+    {{^metadata.hideCode}}
     <a href="/playground/#url={{host}}{{urlSource}}" class="button"> 
       <amp-img srcset="/img/ic_mode_edit_white_24dp_1x.png 1x, /img/ic_mode_edit_white_24dp_2x.png 2x" width="24" height="24" alt="edit"></amp-img>
       <span>Edit in Playground</span>
     </a>
+    {{/metadata.hideCode}}
     {{/urlSource}}
     {{#metadata.preview}}
     <a href="{{urlPreview}}" class="button hide-on-mobile"> 


### PR DESCRIPTION
- amp-form: spacing around inputs
- don't show playground link for samples without code
- amp-fit-text: but each box in a new line
- amp-selector: fix list item height