### PR TITLE
Remove unused amp-sidebar

### DIFF
--- a/src/50_Samples_%26_Templates/Product.html
+++ b/src/50_Samples_%26_Templates/Product.html
@@ -25,7 +25,6 @@ This sample showcases how to build a product page in AMP HTML.
     <script async custom-element="amp-lightbox" src="https://cdn.ampproject.org/v0/amp-lightbox-0.1.js"></script>
     <script async custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>
     <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
-    <script async custom-element="amp-sidebar" src="https://cdn.ampproject.org/v0/amp-sidebar-0.1.js"></script>
     <script async custom-element="amp-selector" src="https://cdn.ampproject.org/v0/amp-selector-0.1.js"></script>
     <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
 


### PR DESCRIPTION
Including unused libraries creates warnings, better to remove them.
@sebastianbenz PTAL