### PR TITLE
adds amp-ad library

### DIFF
--- a/src/20_Components/amp-sticky-ad.html
+++ b/src/20_Components/amp-sticky-ad.html
@@ -16,6 +16,7 @@
     Import the `amp-sticky-ad` component in the header.
   -->
   <script async custom-element="amp-sticky-ad" src="https://cdn.ampproject.org/v0/amp-sticky-ad-1.0.js"></script>
+  <script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script>
   <link rel="canonical" href="<%host%>/components/amp-sticky-ad/">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>

--- a/src/50_Samples_%26_Templates/News_Article.html
+++ b/src/50_Samples_%26_Templates/News_Article.html
@@ -24,6 +24,7 @@ This is a sample template for a news article in AMP. It demonstrates the usage o
     <script async custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
     <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js"></script>
     <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
+    <script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script>
 
     <link rel="canonical" href="<%host%>/samples_templates/news_article/">
 


### PR DESCRIPTION
Without the amp-ad library, the validator gives the following error:
The tag 'amp-ad extension .js script' is missing or incorrect, but required by 'amp-ad'. This will soon be an error.
@sebastianbenz PTAL