### PR TITLE
Add amp-list custom spinner sample

### DIFF
--- a/backend/slow-response.go
+++ b/backend/slow-response.go
@@ -18,6 +18,8 @@ package backend
 
 import (
 	"net/http"
+	"strconv"
+	"fmt"
 	"time"
 )
 
@@ -26,14 +28,15 @@ const (
 )
 
 func InitSlowResponseSample() {
-	http.HandleFunc(SLOW_RESPONSE_SAMPLE_PATH +"rates", roomRates)
+	http.HandleFunc(SLOW_RESPONSE_SAMPLE_PATH +"", sleep)
 }
 
-func roomRates(w http.ResponseWriter, r *http.Request) {
+func sleep(w http.ResponseWriter, r *http.Request) {
 	EnableCors(w, r)
 	SetContentTypeJson(w)
-	response := "{\"items\":[{\"title\": \"This response was delayed. Reload the page if you didn't see the spinner.\"}]}"
-	duration := time.Duration(10)*time.Second
+	delay, _ := strconv.ParseUint(r.URL.Query().Get("delay"), 0, 64)
+	response := fmt.Sprintf("{\"items\":[{\"title\": \"This response was delayed %v milliseconds. Reload the page if you didn't see the spinner.\"}]}", delay)
+	duration := time.Duration(delay)*time.Millisecond
 	time.Sleep(duration)
 	w.Write([]byte(response))
 }

--- a/backend/slow-response.go
+++ b/backend/slow-response.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 
-// Provide a simple JSON response with a noticeable delay
+// Provide a simple JSON response with a customizable delay
 package backend
 
 import (

--- a/backend/slow-response.go
+++ b/backend/slow-response.go
@@ -1,0 +1,39 @@
+// Copyright Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+// Provide a simple JSON response with a noticeable delay
+package backend
+
+import (
+	"net/http"
+	"time"
+)
+
+const (
+	SLOW_RESPONSE_SAMPLE_PATH = "/" + CATEGORY_SAMPLE_TEMPLATES + "/slow-response/"
+)
+
+func InitSlowResponseSample() {
+	http.HandleFunc(SLOW_RESPONSE_SAMPLE_PATH +"rates", roomRates)
+}
+
+func roomRates(w http.ResponseWriter, r *http.Request) {
+	EnableCors(w, r)
+	SetContentTypeJson(w)
+	response := "{\"items\":[{\"title\": \"This response was delayed. Reload the page if you didn't see the spinner.\"}]}"
+	duration := time.Duration(10)*time.Second
+	time.Sleep(duration)
+	w.Write([]byte(response))
+}

--- a/backend/slow-response.go
+++ b/backend/slow-response.go
@@ -12,14 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 // Provide a simple JSON response with a customizable delay
 package backend
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
-	"fmt"
 	"time"
 )
 
@@ -28,7 +27,7 @@ const (
 )
 
 func InitSlowResponseSample() {
-	http.HandleFunc(SLOW_RESPONSE_SAMPLE_PATH +"", sleep)
+	http.HandleFunc(SLOW_RESPONSE_SAMPLE_PATH+"", sleep)
 }
 
 func sleep(w http.ResponseWriter, r *http.Request) {
@@ -36,7 +35,7 @@ func sleep(w http.ResponseWriter, r *http.Request) {
 	SetContentTypeJson(w)
 	delay, _ := strconv.ParseUint(r.URL.Query().Get("delay"), 0, 64)
 	response := fmt.Sprintf("{\"items\":[{\"title\": \"This response was delayed %v milliseconds. Reload the page if you didn't see the spinner.\"}]}", delay)
-	duration := time.Duration(delay)*time.Millisecond
+	duration := time.Duration(delay) * time.Millisecond
 	time.Sleep(duration)
 	w.Write([]byte(response))
 }

--- a/server.go
+++ b/server.go
@@ -38,6 +38,7 @@ func init() {
 	backend.InitAmpAnalytics()
 	backend.InitCommentSection()
 	backend.InitHotelSample()
+	backend.InitSlowResponseSample()
 	backend.InitPollSample()
 	playground.InitPlayground()
 	http.Handle("/", ServeStaticFiles(HandleNotFound(http.FileServer(http.Dir(DIST_DIR)))))

--- a/src/20_Components/amp-list.html
+++ b/src/20_Components/amp-list.html
@@ -16,6 +16,12 @@
   <link rel="canonical" href="<%host%>/components/amp-list/">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <!--
+    #### CSS for the amp-list loader
+
+    While the runtime fetches the JSON content from the endpoint, it will display a loading indicator. It consists of three `div`s with the class `i-amphtml-loader-dot`, all within a `div.i-amphtml-loader`, which lastly is placed in a `div.i-amphtml-loading-container`.
+
+    We'll set up a 3D spinner instead (inspired by http://tobiasahlin.com/spinkit/), by hiding the dots and styling the `.i-amphtml-loader`. The background of the loader's container was styled so we can check that the spinner is vertically centered. -->
   <style amp-custom>
   amp-list {
     margin-left: 16px;
@@ -25,16 +31,10 @@
     bottom: 0;
     right: 0;
   }
-  <!--
-    #### CSS for the amp-list loader
 
-    While the runtime fetches the JSON content from the endpoint, it will display a loading indicator. It consists of three `div`s with the class `i-amphtml-loader-dot`, all within a `div.i-amphtml-loader`, which lastly is placed in a `div.i-amphtml-loading-container`.
-
-    We'll set up a 3D spinner instead (inspired by http://tobiasahlin.com/spinkit/), by hiding the dots and styling the `.i-amphtml-loader`. The background of the loader's container was styled so we can check that the spinner is vertically centered. -->
   .i-amphtml-loading-container {
     background: #DFE8EC;
   }
-
   .i-amphtml-loader.amp-active {
     max-width: 10%;
     max-height: 50%;
@@ -45,14 +45,12 @@
     margin: -1em auto;
     animation: sk-rotateplane 1.2s infinite ease-in-out;
   }
-
   @keyframes sk-rotateplane {
     0% { transform: perspective(120px); }
     50% { transform: perspective(120px) rotateX(-180deg); }
     100% { transform: perspective(120px) rotateX(-180deg) rotateY(-180deg); }
   }
-
-  <!-- Hide the three default dots -->
+  /* Hide the three default dots */
   .i-amphtml-loader-dot {
     display: none;
   }
@@ -99,7 +97,7 @@
   <!--
     The `slow-response` endpoint returns a basic JSON response, with a delay of 10 seconds. If the spinner is not visible, reload the page and scroll to this section if necessary.
   -->
-  <amp-list width="auto" height="100" layout="fixed-height" src="<%host%>/samples_templates/slow-response/rates">
+  <amp-list width="auto" height="250" layout="fixed-height" src="<%host%>/samples_templates/slow-response/?delay=10000">
     <template type="amp-mustache">
       <div>
         <p>{{title}}</p>

--- a/src/20_Components/amp-list.html
+++ b/src/20_Components/amp-list.html
@@ -25,6 +25,38 @@
     bottom: 0;
     right: 0;
   }
+  <!--
+    #### CSS for the amp-list loader
+
+    While the runtime fetches the JSON content from the endpoint, it will display a loading indicator. It consists of three `div`s with the class `i-amphtml-loader-dot`, all within a `div.i-amphtml-loader`, which lastly is placed in a `div.i-amphtml-loading-container`.
+
+    We'll set up a 3D spinner instead (inspired by http://tobiasahlin.com/spinkit/), by hiding the dots and styling the `.i-amphtml-loader`. The background of the loader's container was styled so we can check that the spinner is vertically centered. -->
+  .i-amphtml-loading-container {
+    background: #DFE8EC;
+  }
+
+  .i-amphtml-loader.amp-active {
+    max-width: 10%;
+    max-height: 50%;
+    width: 2em;
+    height: 2em;
+    background-color: #333;
+
+    margin: -1em auto;
+    animation: sk-rotateplane 1.2s infinite ease-in-out;
+  }
+
+  @keyframes sk-rotateplane {
+    0% { transform: perspective(120px); }
+    50% { transform: perspective(120px) rotateX(-180deg); }
+    100% { transform: perspective(120px) rotateX(-180deg) rotateY(-180deg); }
+  }
+
+  <!-- Hide the three default dots -->
+  .i-amphtml-loader-dot {
+    display: none;
+  }
+
   </style>
 </head>
 <body>
@@ -61,6 +93,18 @@
   -->
   <amp-list width="auto" height="100" layout="fixed-height" src="<%host%>/json/examples.json"
       template="amp-template-id">
+  </amp-list>
+
+  <!-- #### Displaying a loading indicator -->
+  <!--
+    The `slow-response` endpoint returns a basic JSON response, with a delay of 10 seconds. If the spinner is not visible, reload the page and scroll to this section if necessary.
+  -->
+  <amp-list width="auto" height="100" layout="fixed-height" src="<%host%>/samples_templates/slow-response/rates">
+    <template type="amp-mustache">
+      <div>
+        <p>{{title}}</p>
+      </div>
+    </template>
   </amp-list>
 
   <!-- #### Handling List Overflow -->

--- a/src/20_Components/amp-list.html
+++ b/src/20_Components/amp-list.html
@@ -19,9 +19,9 @@
   <!--
     #### CSS for the amp-list loader
 
-    While the runtime fetches the JSON content from the endpoint, it will display a loading indicator. It consists of three `div`s with the class `i-amphtml-loader-dot`, all within a `div.i-amphtml-loader`, which lastly is placed in a `div.i-amphtml-loading-container`.
+    While the runtime fetches the JSON content from the endpoint, it will display a loading indicator. It consists of three `div`s all within a `div.i-amphtml-loader`, which lastly is placed in a `div.i-amphtml-loading-container`.
 
-    We'll set up a 3D spinner instead (inspired by http://tobiasahlin.com/spinkit/), by hiding the dots and styling the `.i-amphtml-loader`. The background of the loader's container was styled so we can check that the spinner is vertically centered. -->
+    We'll set up a 3D spinner instead (inspired by http://tobiasahlin.com/spinkit/), by hiding the dots and styling their outer div. Since [`i-amp...` classes are not meant to be customized](https://www.ampproject.org/docs/reference/spec#class-and-tag-names), we'll target the `.amp-active` class that the runtime adds to the loader during its display. -->
   <style amp-custom>
   amp-list {
     margin-left: 16px;
@@ -32,10 +32,7 @@
     right: 0;
   }
 
-  .i-amphtml-loading-container {
-    background: #DFE8EC;
-  }
-  .i-amphtml-loader.amp-active {
+  .custom-loader .amp-active {
     max-width: 10%;
     max-height: 50%;
     width: 2em;
@@ -51,7 +48,7 @@
     100% { transform: perspective(120px) rotateX(-180deg) rotateY(-180deg); }
   }
   /* Hide the three default dots */
-  .i-amphtml-loader-dot {
+  .custom-loader .amp-active > div {
     display: none;
   }
 
@@ -95,9 +92,9 @@
 
   <!-- #### Displaying a loading indicator -->
   <!--
-    The `slow-response` endpoint returns a basic JSON response, with a delay of 10 seconds. If the spinner is not visible, reload the page and scroll to this section if necessary.
+    The `slow-response` endpoint returns a basic JSON response, with a delay of 10 seconds. If the loading animation is not visible, reload the page and scroll to this section if necessary.
   -->
-  <amp-list width="auto" height="250" layout="fixed-height" src="<%host%>/samples_templates/slow-response/?delay=10000">
+  <amp-list class="custom-loader" width="auto" height="250" layout="fixed-height" src="<%host%>/samples_templates/slow-response/?delay=10000">
     <template type="amp-mustache">
       <div>
         <p>{{title}}</p>


### PR DESCRIPTION
Customizing the `amp-list` spinner is not documented yet. (The fact that a spinner exists is not actually mentioned in the docs [at all](http://stackoverflow.com/questions/42034524/display-loading-indicator-while-amp-list-loads-the-content).) This sample is the first step towards fixing that.

![2017-02-03 18 30 54 608](https://cloud.githubusercontent.com/assets/33569/22614927/f0906b34-ea3e-11e6-8029-2cc809a03fc7.gif)
