### PR TITLE
fix-image-gallery

### DIFF
--- a/src/30_Advanced/Image_Galleries_with_amp-carousel.html
+++ b/src/30_Advanced/Image_Galleries_with_amp-carousel.html
@@ -144,10 +144,10 @@ first described in text and paintings in medieval times.
   attribute in the `<p>` tag above the carousel to update as well.
 
   Only [whitelisted functions](https://www.ampproject.org/es/docs/reference/components/amp-bind)
-  are allowed when using `amp-bind`. We use the syntax `+ selectedSlide` to make sure the variable is casted into an integer.
+  are allowed when using `amp-bind`. We use the unary plus operator before selectedSlide to cast it into an integer.
   -->
   <div>
-    <p> Selected slide: <span [text]="(+ selectedSlide + 1)">1</span>/3</p>
+    <p> Selected slide: <span [text]="+ selectedSlide + 1">1</span>/3</p>
 
     <amp-carousel controls type="slides" width="400" height="300"
     [slide]="selectedSlide" on="slideChange:AMP.setState(selectedSlide=event.index)">

--- a/src/30_Advanced/Image_Galleries_with_amp-carousel.html
+++ b/src/30_Advanced/Image_Galleries_with_amp-carousel.html
@@ -144,7 +144,7 @@ first described in text and paintings in medieval times.
   attribute in the `<p>` tag above the carousel to update as well.
 
   Only [whitelisted functions](https://www.ampproject.org/es/docs/reference/components/amp-bind)
-  are allowed when using `amp-bind`. We use the unary plus operator before selectedSlide to cast it into an integer.
+  are allowed when using `amp-bind`. We use the unary plus operator before `selectedSlide` to cast it into an integer.
   -->
   <div>
     <p> Selected slide: <span [text]="+ selectedSlide + 1">1</span>/3</p>

--- a/src/30_Advanced/Image_Galleries_with_amp-carousel.html
+++ b/src/30_Advanced/Image_Galleries_with_amp-carousel.html
@@ -144,7 +144,7 @@ first described in text and paintings in medieval times.
   attribute in the `<p>` tag above the carousel to update as well.
   -->
   <div>
-    <p> Selected slide: <span [text]="(selectedSlide + 1)">1</span>/3</p>
+    <p> Selected slide: <span [text]="(selectedSlide * 1 + 1)">1</span>/3</p>
 
     <amp-carousel controls type="slides" width="400" height="300"
     [slide]="selectedSlide" on="slideChange:AMP.setState(selectedSlide=event.index)">

--- a/src/30_Advanced/Image_Galleries_with_amp-carousel.html
+++ b/src/30_Advanced/Image_Galleries_with_amp-carousel.html
@@ -142,9 +142,12 @@ first described in text and paintings in medieval times.
 
   Whenever the carousel slide changes, it updates `selectedSlide`. This causes the `text`
   attribute in the `<p>` tag above the carousel to update as well.
+
+  Only [whitelisted functions](https://www.ampproject.org/es/docs/reference/components/amp-bind)
+  are allowed when using `amp-bind`. We use the syntax `+ selectedSlide` to make sure the variable is casted into an integer.
   -->
   <div>
-    <p> Selected slide: <span [text]="(selectedSlide * 1 + 1)">1</span>/3</p>
+    <p> Selected slide: <span [text]="(+ selectedSlide + 1)">1</span>/3</p>
 
     <amp-carousel controls type="slides" width="400" height="300"
     [slide]="selectedSlide" on="slideChange:AMP.setState(selectedSlide=event.index)">


### PR DESCRIPTION
Fixes #631 

When using amp-selector, the option is a string. When applying the mathematical a+1, given a is a string, the result will be "a+1".

Amp-bind doesn't support Number.parseInt so using *1 will ensure the cast to a number.

@sebastianbenz PTAL