### PR TITLE
amp-start css in preview.html

### DIFF
--- a/templates/preview.html
+++ b/templates/preview.html
@@ -5,7 +5,7 @@
     {{> head.html}}
     <style amp-custom>
       {{> css/code.css}}
-      {{> css/material.css}}
+      {{> css/ampstart.css}}
       {{> css/styles.css}}
       {{> css/preview.css}}
       {{{exampleStyles}}}


### PR DESCRIPTION
@sebastianbenz This was not included in first pull request, previews are not getting the amp-start css.