### PR TITLE
Ampstart preview mobile

### DIFF
--- a/src/50_Samples_%26_Templates/Product.html
+++ b/src/50_Samples_%26_Templates/Product.html
@@ -576,7 +576,7 @@ div.square {
         </div>
       </form>
 
-    <!-- ## Collapsibles/Accordion -->
+    <!-- ## Collapsibles / Accordion -->
     <!-- Use `amp-accordion` to hide and show additional data about your product. Learn more about `amp-accordion` [here](/components/amp-accordion/). -->
     <div>
       <amp-accordion>

--- a/templates/css/example.css
+++ b/templates/css/example.css
@@ -33,6 +33,7 @@ pre > code {
 }
 .www-component-desc > pre > code,
 .abe-code pre {
+  white-space: pre-wrap;
   overflow-x: auto;
   padding: 0;
   margin: 0;
@@ -64,9 +65,6 @@ pre > code {
 }
 .abe-preview {
   background: #fff;
-}
-.abe-experiment-warning .abe-experiment-warning-buttons {
-  justify-content: center;
 }
 
 

--- a/templates/css/preview.css
+++ b/templates/css/preview.css
@@ -1,16 +1,17 @@
 body {
-  background: #444;
+  background: #f9f7f7;
+  opacity: .8;
 }
 #abe-preview-header {
-  background-image: linear-gradient(90deg,#94103e 0,#db004d);
+  background: #fff;
+  color: #000;
   height: 56px;
-}
-#abe-preview-header > a {
-  color: white;
+  width: 100vw;
 }
 #abe-preview {
   background: #fff;
   min-height: 100vh;
+  width: 100vw;
   margin: 0 auto; 
   max-width: 960px;
   margin-top: 56px;

--- a/templates/experiment.html
+++ b/templates/experiment.html
@@ -1,10 +1,10 @@
-<div class="abe-experiment-warning ampstart-card p1 mb2 ">
+<div class="abe-experiment-warning ampstart-card p1">
   <h4 class="mb1">Experimental Mode</h4>
-  <p class="mb1">This example uses the following experimental feature{{#metadata.experiments.1}}s{{/metadata.experiments.1}}: <code class="amp-experiment-list">[{{#metadata.experiments}}<span>{{.}}</span>{{/metadata.experiments}}]</code>. Enable the experiment via the button below. Some components require the AMP Dev Channel to be enabled as well. <a href="https://www.ampproject.org/docs/reference/experimental.html">Learn more here</a>.</p>
+  <p>This example uses the following experimental feature{{#metadata.experiments.1}}s{{/metadata.experiments.1}}: <code class="amp-experiment-list">[{{#metadata.experiments}}<span>{{.}}</span>{{/metadata.experiments}}]</code>. Enable the experiment via the button below. Some components require the AMP Dev Channel to be enabled as well. <a href="https://www.ampproject.org/docs/reference/experimental.html">Learn more here</a>.</p>
 
-  <div class="abe-experiment-warning-buttons mx1 flex flex-center">
-    <button id="experiment-toggle" class="ampstart-btn ampstart-btn-secondary caps mx2" disabled>Enable Experiment{{#metadata.experiments.1}}s{{/metadata.experiments.1}}</button>
-    <button id="canary-toggle" class="ampstart-btn ampstart-btn-secondary caps mx2" disabled>
+  <div class="abe-experiment-warning-buttons flex flex-wrap">
+    <button id="experiment-toggle" class="ampstart-btn ampstart-btn-secondary caps mr1 mt1" disabled>Enable Experiment{{#metadata.experiments.1}}s{{/metadata.experiments.1}}</button>
+    <button id="canary-toggle" class="ampstart-btn ampstart-btn-secondary caps mt1" disabled>
       <a class="caps inline-block white text-decoration-none" href="https://cdn.ampproject.org/experiments.html" target="_blank">Enable Dev Channel</a>
     </button>
   </div>

--- a/templates/preview.html
+++ b/templates/preview.html
@@ -15,18 +15,20 @@
     {{{elementsAfterBody}}}
     {{^isEmbed}}
       <div id="abe-preview-header" class="ampstart-headerbar fixed flex justify-start items-center top-0 left-0 right-0 pl2 pr4">
-        <a href=".." class="white caps text-decoration-none">
-          <i class="align-middle inline-block mr1"><svg fill="#FFFFFF" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+        <a href=".." class="truncate caps text-decoration-none">
+          <i class="align-middle inline-block mr1"><svg fill="#000000" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
               <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>
               <path d="M0 0h24v24H0z" fill="none"/>
             </svg></i>
-            View annotated Source
+            Demo: {{subHeading}}
         </a>
       </div>
-    <div id="abe-preview" class="ampstart-card">
-      {{#metadata.experiments.length}}
-      {{> experiment.html}}
-      {{/metadata.experiments.length}}
+    <div id="abe-preview" class="ampstart-card m1">
+      <div class="p1">
+        {{#metadata.experiments.length}}
+        {{> experiment.html}}
+        {{/metadata.experiments.length}}
+      </div>
     {{/isEmbed}}
       {{#sections}}
       {{{preview}}}


### PR DESCRIPTION
* fix content overflowing
* change preview color scheme to white (similar to ampstart)
* align experiment buttons to the left
* fix code formatting
* show truncated demo title in header
* fix product title overflowing sidebar