### PR TITLE
Adds margin to amp-bind

### DIFF
--- a/src/20_Components/amp-bind.html
+++ b/src/20_Components/amp-bind.html
@@ -41,6 +41,9 @@
     .greenBackground {
       background-color: green;
     }
+    .abe-preview > p {
+      padding: 1rem;
+    }
   </style>
 </head>
 <body>
@@ -101,29 +104,25 @@ changes. `currentAnimal` is an uninitialized implicit state variable, which will
    set when a state change is triggered (see below).
 
 -->
-<div class="p1">
-  <p [text]="'This is a ' + currentAnimal + '.'">This is a dog.</p>
-</div>
+<p [text]="'This is a ' + currentAnimal + '.'">This is a dog.</p>
 
 <!-- ## Binding Styles -->
 <!--
   Styling can be changed by applying css classes. It will override all the element's style classes. `allAnimals` is the `id` of the &lt;amp-state&gt; component above.
 -->
-<div class="p1">
   <p [class]="allAnimals[currentAnimal].style" class="greenBackground">Each animal has a different background color.</p>
-</div>
 <!-- ## Binding Attribute Values -->
 <!--
 Various AMP components support binding attribute values with amp-bind. For example, `amp-img` URLs can be changed.
 -->
-  <amp-img src="/img/Border_Collie.jpg" class="m1" width="300" height="200"
+  <amp-img src="/img/Border_Collie.jpg" layout="responsive" width="300" height="200"
       [src]="allAnimals[currentAnimal].imageUrl">
   </amp-img>
 
   <!--
     The src URL for videos embedded with `amp-video` can be changed. At the moment, among all the AMP video components, only amp-video supports amp-bind.
   -->
-  <amp-video src="/video/dog-video.mp4" class="m1" [src]="allAnimals[currentAnimal].videoUrl" width="300" height="200" autoplay controls="true"></amp-video>
+  <amp-video src="/video/dog-video.mp4" layout="responsive" [src]="allAnimals[currentAnimal].videoUrl" width="300" height="200" autoplay controls="true"></amp-video>
 
   <!-- ## Triggering updates -->
   <!--

--- a/src/20_Components/amp-bind.html
+++ b/src/20_Components/amp-bind.html
@@ -101,27 +101,29 @@ changes. `currentAnimal` is an uninitialized implicit state variable, which will
    set when a state change is triggered (see below).
 
 -->
-<p [text]="'This is a ' + currentAnimal + '.'">This is a dog.</p>
+<div class="p1">
+  <p [text]="'This is a ' + currentAnimal + '.'">This is a dog.</p>
+</div>
 
 <!-- ## Binding Styles -->
 <!--
   Styling can be changed by applying css classes. It will override all the element's style classes. `allAnimals` is the `id` of the &lt;amp-state&gt; component above.
 -->
-
-<p [class]="allAnimals[currentAnimal].style" class="greenBackground">Each animal has a different background color.</p>
-
+<div class="p1">
+  <p [class]="allAnimals[currentAnimal].style" class="greenBackground">Each animal has a different background color.</p>
+</div>
 <!-- ## Binding Attribute Values -->
 <!--
 Various AMP components support binding attribute values with amp-bind. For example, `amp-img` URLs can be changed.
 -->
-  <amp-img src="/img/Border_Collie.jpg" width="300" height="200"
+  <amp-img src="/img/Border_Collie.jpg" class="m1" width="300" height="200"
       [src]="allAnimals[currentAnimal].imageUrl">
   </amp-img>
 
   <!--
     The src URL for videos embedded with `amp-video` can be changed. At the moment, among all the AMP video components, only amp-video supports amp-bind.
   -->
-  <amp-video src="/video/dog-video.mp4" [src]="allAnimals[currentAnimal].videoUrl" width="300" height="200" autoplay controls="true"></amp-video>
+  <amp-video src="/video/dog-video.mp4" class="m1" [src]="allAnimals[currentAnimal].videoUrl" width="300" height="200" autoplay controls="true"></amp-video>
 
   <!-- ## Triggering updates -->
   <!--
@@ -132,7 +134,7 @@ Various AMP components support binding attribute values with amp-bind. For examp
   - Existing state can be overwritten, including state initialized by
     &lt;amp-state&gt; components
   -->
-  <button class="ampstart-btn caps"
+  <button class="ampstart-btn caps m1"
       on="tap:AMP.setState(currentAnimal='cat')">Set to Cat</button>
 </body>
 </html>


### PR DESCRIPTION
I add to add divs for the paragraphs as the class is overwritten by amp-bind. The alternative is to add a css rule using the parent but that would increase the css duplicating the style.