### PR TITLE
Update footer.snip.html

### DIFF
--- a/templates/ampstart/footer.snip.html
+++ b/templates/ampstart/footer.snip.html
@@ -18,7 +18,7 @@ limitations under the License.
 
 {{#footer}}
   <!-- Start Footer -->
-  <footer class="ampstart-footer flex flex-column items-center p3">
+  <footer class="ampstart-footer flex flex-column items-center pxy3">
     {{> ampstart/social-follow.snip.html}}
     {{#faq-links}}
       <nav class="ampstart-footer-nav">


### PR DESCRIPTION
This fixes the padding for the footer. There is a top-bottom padding rule inherited from ampstart-footer class.
Currently is: 
![footer](https://cloud.githubusercontent.com/assets/820891/23589756/9330178a-01d3-11e7-8171-8ee4a24cbdb0.png)
