### PR TITLE
fix amp-image-lightbox layout

### DIFF
--- a/src/20_Components/amp-image-lightbox.html
+++ b/src/20_Components/amp-image-lightbox.html
@@ -43,6 +43,7 @@
            src="/img/Hovawart.jpg"
            alt="Picture of a dog"
            title="Picture of a dog, view in lightbox"
+           layout="responsive"
            width="600" height="400"></amp-img>
 
   <!-- ## Captions -->
@@ -58,6 +59,7 @@
              src="/img/Border_Collie.jpg"
              alt="Picture of a dog"
              title="Picture of a dog, view in lightbox"
+             layout="responsive"
              width="300" height="246"></amp-img>
     <figcaption>Border Collie.</figcaption>
   </figure>


### PR DESCRIPTION
This adds layout responsive to the image which is now too big for the card.
![dog-lightbox](https://cloud.githubusercontent.com/assets/820891/23590006/7de74cf4-01d8-11e7-97b5-c0d296007016.png)
