### PR TITLE
Remove wrapping of links with buttons

### DIFF
--- a/templates/css/shared.css
+++ b/templates/css/shared.css
@@ -39,4 +39,7 @@ body {
 .ampstart-sidebar {
   width: 340px;
 }
-
+.ampstart-btn.disabled {
+  pointer-events: none;
+  opacity: 0.5;
+}

--- a/templates/css/shared.css
+++ b/templates/css/shared.css
@@ -43,3 +43,10 @@ body {
   pointer-events: none;
   opacity: 0.5;
 }
+.ampstart-btn {
+  color: #b60845;
+  border: 1px solid #b60845;
+}
+a.ampstart-btn-secondary {
+  color: #fff;
+}

--- a/templates/example.html
+++ b/templates/example.html
@@ -30,13 +30,11 @@
         {{/github}}
 
         <div class="www-index-header-action mx-auto">
-          <button class="ampstart-btn ampstart-btn-secondary caps mb1 mx2 xs-hide sm-hide">
-            <a class="text-decoration-none block" href="/playground/#url={{host}}{{urlSource}}" >Open in Playground</a>
-          </button>
+          <a class="ampstart-btn ampstart-btn-secondary caps mb1 mx2 xs-hide sm-hide"
+            href="/playground/#url={{host}}{{urlSource}}"><span class="text-decoration-none block">Open in Playground</span></a>
           {{#metadata.preview}}
-          <button class="ampstart-btn ampstart-btn-secondary caps mb1 mx2">
-            <a class="text-decoration-none block" href="preview" >View Demo</a>
-          </button>
+          <a class="ampstart-btn ampstart-btn-secondary caps mb1 mx2"
+            href="preview"><span class="text-decoration-none block">View Demo</span></a>
           {{/metadata.preview}}
       </div>
     </header>

--- a/templates/experiment.html
+++ b/templates/experiment.html
@@ -4,9 +4,9 @@
 
   <div class="abe-experiment-warning-buttons flex flex-wrap">
     <button id="experiment-toggle" class="ampstart-btn ampstart-btn-secondary caps mr1 mt1" disabled>Enable Experiment{{#metadata.experiments.1}}s{{/metadata.experiments.1}}</button>
-    <button id="canary-toggle" class="ampstart-btn ampstart-btn-secondary caps mt1" disabled>
-      <a class="caps inline-block white text-decoration-none" href="https://cdn.ampproject.org/experiments.html" target="_blank">Enable Dev Channel</a>
-    </button>
+    <a id="canary-toggle"
+      class="ampstart-btn ampstart-btn-secondary caps mt1 disabled"
+      href="https://cdn.ampproject.org/experiments.html" target="_blank"><span class="caps inline-block white text-decoration-none">Enable Dev Channel</span></a>
   </div>
 </div>
 <!-- BEGIN INVALID AMP - don't try at home -->
@@ -14,9 +14,13 @@
 document.addEventListener("DOMContentLoaded", function(event) {
   (window.AMP = window.AMP || []).push(function(AMP) {
 
-    function enableButton(button) {
-      const element = document.getElementById(button);
-      element.removeAttribute('disabled');
+    function enableButton(elementId) {
+      const element = document.getElementById(elementId);
+      if (element.nodeName.toLowerCase() === 'button') {
+        element.removeAttribute('disabled');
+      } else {
+        element.classList.remove('disabled');
+      }
     }
 
     function areAllExperimentsEnabled() {

--- a/templates/index.html
+++ b/templates/index.html
@@ -79,9 +79,11 @@
             {{#description}} <p class="mb1">{{{ description }}}</p> {{/description}}
             <div class="abe-sample-card-actions">
               {{#metadata.preview}}
-              <button class="ampstart-btn ampstart-btn-secondary caps"><a class="text-decoration-none inline-block" href="{{urlPreview}}">Demo</a></button>
+              <a class="ampstart-btn ampstart-btn-secondary caps"
+                href="{{urlPreview}}"><span class="text-decoration-none inline-block">Demo</span></a>
               {{/metadata.preview}}
-              <button class="ampstart-btn caps"><a class="text-decoration-none inline-block" href="{{url}}">Code</a></button>
+              <a class="ampstart-btn caps"
+                href="{{url}}"><span class="text-decoration-none inline-block">Code</span></a>
             </div>
           </div>
           {{/examples}}


### PR DESCRIPTION
I removed the button-elements, which makes imho no sense from a semantic point of view. Also it breaks the links in Firefox and makes them unusable.

Atm the `disabled`-styles are missing. I'll add them, when the [styles "issue"](https://github.com/ampproject/amp-by-example/pull/680#issuecomment-285877353) is solved.