### PR TITLE
amp-graphiq examples (WIP)

### DIFF
--- a/src/20_Components/amp-graphiq.html
+++ b/src/20_Components/amp-graphiq.html
@@ -1,0 +1,53 @@
+<!--
+  ## Introduction
+
+  Embed [Graphiq](https://www.graphiq.com) embeds into your AMP HTML files.
+-->
+
+<!---{
+  "draft": true
+}--->
+
+<!-- -->
+
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="<%host%>/components/amp-graphiq/">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <!-- ## Setup -->
+  <!-- Import the amp-graphiq component in the header -->
+  <script async custom-element="amp-graphiq" src="https://cdn.ampproject.org/v0/amp-graphiq-0.1.js"></script>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+</head>
+<body>
+
+  <!-- ## Basic Usage -->
+  <!--
+     Graphiq widgets are embedded via the Graphiq widget id, which is passed via the data-widget-id attribute. You may pass any valid dimensions for your chosen layout, and the component will resize its height as necessary once the embed is rendered.
+   -->
+<amp-graphiq
+    data-widget-id="dUuriXJo2qx"
+    width="600"
+    height="512"
+    layout="responsive">
+</amp-graphiq>
+
+  <!--
+    Embeds also accept an optional data-href value, which is a url that will provide the user
+    with more information about the data presented in the widget.  By default the url will take
+    the user to the widget's landing page on Graphiq.com
+  -->
+
+  <amp-graphiq
+    data-widget-id="dUuriXJo2qx"
+    data-href="https://general-by-state.insidegov.com/l/19/Wisconsin"
+    width="600"
+    height="512"
+    layout="responsive">
+</amp-graphiq>
+
+</body>
+</html>


### PR DESCRIPTION
Adding initial examples for [amp-graphiq](https://github.com/ampproject/amphtml/pull/8000).  Currently set as 'draft' until `amp-graphiq` is accepted and released.