### PR TITLE
Add padding to menu

### DIFF
--- a/src/50_Samples_%26_Templates/Product_Listing.html
+++ b/src/50_Samples_%26_Templates/Product_Listing.html
@@ -57,13 +57,13 @@ This sample showcases how to build a product listing page in AMP HTML.
     Use the [amp-sidebar](/components/amp-sidebar/) component to give customers the chance to quickly jump to any of your product categories.
   -->
   <amp-sidebar id="drawermenu" layout="nodisplay">
-    <div class="topheader">
+    <div class="topheader p1">
       <a href="/" class="home">Products by Example</a>
     </div>
     <hr/>
-    <h2 class="category expanded"><a href="/samples_templates/product_listing/preview/">Fruit</a></h2>
-    <h2 class="category"><a href="/samples_templates/product_listing/preview/">Vegetable</a></h2>
-    <h2 class="category"><a href="/samples_templates/product_listing/preview/">More</a></h2>
+    <h2 class="category expanded p1"><a href="/samples_templates/product_listing/preview/">Fruit</a></h2>
+    <h2 class="category p1"><a href="/samples_templates/product_listing/preview/">Vegetable</a></h2>
+    <h2 class="category p1"><a href="/samples_templates/product_listing/preview/">More</a></h2>
   </amp-sidebar>
   <!-- ## Header with Search -->
   <!--

--- a/src/50_Samples_%26_Templates/Product_Listing.html
+++ b/src/50_Samples_%26_Templates/Product_Listing.html
@@ -57,13 +57,13 @@ This sample showcases how to build a product listing page in AMP HTML.
     Use the [amp-sidebar](/components/amp-sidebar/) component to give customers the chance to quickly jump to any of your product categories.
   -->
   <amp-sidebar id="drawermenu" layout="nodisplay">
-    <div class="topheader p1">
-      <a href="/" class="home">Products by Example</a>
+    <div class="h2 p1">
+      <a href="/" class="text-decoration-none">Products by Example</a>
     </div>
     <hr/>
-    <h2 class="category expanded p1"><a href="/samples_templates/product_listing/preview/">Fruit</a></h2>
-    <h2 class="category p1"><a href="/samples_templates/product_listing/preview/">Vegetable</a></h2>
-    <h2 class="category p1"><a href="/samples_templates/product_listing/preview/">More</a></h2>
+    <h3 class="expanded p1"><a class="text-decoration-none" href="/samples_templates/product_listing/preview/">Fruit</a></h2>
+    <h3 class="p1"><a class="text-decoration-none" href="/samples_templates/product_listing/preview/">Vegetable</a></h2>
+    <h3 class="p1"><a class="text-decoration-none" href="/samples_templates/product_listing/preview/">More</a></h2>
   </amp-sidebar>
   <!-- ## Header with Search -->
   <!--

--- a/src/50_Samples_%26_Templates/Product_Listing.html
+++ b/src/50_Samples_%26_Templates/Product_Listing.html
@@ -61,9 +61,9 @@ This sample showcases how to build a product listing page in AMP HTML.
       <a href="/" class="text-decoration-none">Products by Example</a>
     </div>
     <hr/>
-    <h3 class="expanded p1"><a class="text-decoration-none" href="/samples_templates/product_listing/preview/">Fruit</a></h2>
-    <h3 class="p1"><a class="text-decoration-none" href="/samples_templates/product_listing/preview/">Vegetable</a></h2>
-    <h3 class="p1"><a class="text-decoration-none" href="/samples_templates/product_listing/preview/">More</a></h2>
+    <h3 class="expanded p1"><a class="text-decoration-none" href="/samples_templates/product_listing/preview/">Fruit</a></h3>
+    <h3 class="p1"><a class="text-decoration-none" href="/samples_templates/product_listing/preview/">Vegetable</a></h3>
+    <h3 class="p1"><a class="text-decoration-none" href="/samples_templates/product_listing/preview/">More</a></h3>
   </amp-sidebar>
   <!-- ## Header with Search -->
   <!--


### PR DESCRIPTION
This adds padding to the menu of the product-listing sample.
This is the current menu without padding:
![menu-margin](https://cloud.githubusercontent.com/assets/820891/23952392/43113bae-0989-11e7-81d9-533e273027e5.png)
