### PR TITLE
Fix amp-accordion sample formatting

### DIFF
--- a/src/20_Components/amp-accordion.html
+++ b/src/20_Components/amp-accordion.html
@@ -17,9 +17,6 @@
   <link rel="canonical" href="<%host%>/components/amp-accordion/">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
-  <!--
-    Use `section[expanded]` and `section:not([expanded])` to style the accordion header depending on whether it is expanded or not.
-  -->
   <style amp-custom>
   amp-accordion section[expanded] .show-more {
     display: none;
@@ -40,7 +37,7 @@
 
   <!-- ## Basic Usage -->
   <!--
-    Each of the `amp-accordion` component’s immediate children is considered a section in the accordion. Each of these nodes must be a `<section>` tag. Each `<section>` must contain only two direct children. The first child (of the section) will be considered as the heading of the section. Clicking/tapping on this section will trigger the expand/collapse behaviour. Use the `disable-session-states` attribute to disable preserving the accordion state across a session. 
+    Each of the `amp-accordion` component’s immediate children is considered a section in the accordion. Each of these nodes must be a `<section>` tag. Each `<section>` must contain only two direct children. The first child (of the section) will be considered as the heading of the section. Clicking/tapping on this section will trigger the expand/collapse behaviour. Use the `disable-session-states` attribute to disable preserving the accordion state across a session.
   -->
   <amp-accordion>
     <section expanded>
@@ -64,7 +61,18 @@
   <!-- -->
     <p>Lorem ipsum dolor sit amet, mauris sed, vestibulum velit id, vivamus fermentum sed massa metus semper.</p>
   <!--
-    `amp-accordion` adds the `expanded` attribute to any expanded element. You can use [CSS attribute selectors](https://developer.mozilla.org/en/docs/Web/CSS/Attribute_selectors) to style an accordion section based on whether it's expanded or collapsed. Use `section[expanded]` to style the expanded state and `section:not([expanded])` to style the collapsed state. This example shows a different title based on whether the section is expanded or not.
+    `amp-accordion` adds the `expanded` attribute to any expanded element. You can use [CSS attribute selectors](https://developer.mozilla.org/en/docs/Web/CSS/Attribute_selectors) to style an accordion section based on whether it's expanded or collapsed. Use `section[expanded]` to style the expanded state and `section:not([expanded])` to style the collapsed state.:
+
+  ```
+  amp-accordion section[expanded] .show-more {
+    display: none;
+  }
+  amp-accordion section:not([expanded]) .show-less {
+    display: none;
+  }
+  ```
+
+    This example shows a different title based on whether the section is expanded or not.
   -->
     <amp-accordion disable-session-states>
       <section>
@@ -86,19 +94,19 @@
     <!--
     You can even nest multiple accordions. Just be sure to avoid styling elements based on the expanded state of the enclosing amp-accordion.  In particular, avoid overly generic rules such as:
 
-    ```css
-    section[expanded] h4 {
-      ...
-    }
-    ```
+  ```css
+  section[expanded] h4 {
+    ...
+  }
+  ```
 
     instead directly target elements:
 
-    ```css
-    section[expanded] > h4 {
-      ...
-    }
-    ```
+  ```css
+  section[expanded] > h4 {
+    ...
+  }
+  ```
 
     A nested accordion:
     -->

--- a/templates/css/example.css
+++ b/templates/css/example.css
@@ -46,6 +46,9 @@ code {
   margin-bottom: 2rem;
   padding: 0;
 }
+.www-component-desc > pre {
+  padding: 1rem;
+}
 .www-component-desc > .ampstart-card {
   padding: 1rem;
 }


### PR DESCRIPTION
Hide the css block and show it in the styling section instead. Also
fixes the doc code block formatting.

Fixes #770