### PR TITLE
Add image-lightbox

### DIFF
--- a/src/50_Samples_%26_Templates/Product_Page.html
+++ b/src/50_Samples_%26_Templates/Product_Page.html
@@ -274,6 +274,9 @@ This sample showcases how to build a product page in AMP HTML.
     .items, amp-list.items > div {
       justify-content: flex-start;
     }
+    .close-gallery-button {
+      float: right;
+    }
     </style>
 
     <!-- ## Metadata -->
@@ -502,10 +505,14 @@ This sample showcases how to build a product page in AMP HTML.
     <!-- ## Full screen image -->
     <!-- The `amp-image-lightbox` component allows the user to expand an image to fill the viewport.
     By clicking on each image from the product gallery, the user can see the product image by using the full screen.
-    Learn more [here](https://ampbyexample.com/components/amp-image-lightbox/) -->
+    Learn more [here](/components/amp-image-lightbox/) -->
     <amp-image-lightbox id="gallery-lightbox" layout="nodisplay">
-      <div class="lightbox" on="tap:gallery-lightbox.close" role="button"
+      <div on="tap:gallery-lightbox.close" role="button"
           tabindex="0">
+          <button class="ampstart-btn caps m2 close-gallery-button" on="tap:gallery-lightbox.close"
+            role="button" tabindex="0">
+            Close
+          </button>
       </div>
     </amp-image-lightbox>
 

--- a/src/50_Samples_%26_Templates/Product_Page.html
+++ b/src/50_Samples_%26_Templates/Product_Page.html
@@ -275,7 +275,9 @@ This sample showcases how to build a product page in AMP HTML.
       justify-content: flex-start;
     }
     .close-gallery-button {
-      float: right;
+      z-index: 1;
+      position: absolute;
+      right: 0;
     }
     </style>
 

--- a/src/50_Samples_%26_Templates/Product_Page.html
+++ b/src/50_Samples_%26_Templates/Product_Page.html
@@ -507,7 +507,7 @@ This sample showcases how to build a product page in AMP HTML.
       <div class="lightbox" on="tap:gallery-lightbox.close" role="button"
           tabindex="0">
       </div>
-    </amp-lightbox>
+    </amp-image-lightbox>
 
   </div>
   <!-- ## Product Configuration -->

--- a/src/50_Samples_%26_Templates/Product_Page.html
+++ b/src/50_Samples_%26_Templates/Product_Page.html
@@ -23,6 +23,7 @@ This sample showcases how to build a product page in AMP HTML.
     <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js"></script>
     <script async custom-element="amp-social-share" src="https://cdn.ampproject.org/v0/amp-social-share-0.1.js"></script>
     <script async custom-element="amp-lightbox" src="https://cdn.ampproject.org/v0/amp-lightbox-0.1.js"></script>
+    <script async custom-element="amp-image-lightbox" src="https://cdn.ampproject.org/v0/amp-image-lightbox-0.1.js"></script>
     <script async custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>
     <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
     <script async custom-element="amp-sidebar" src="https://cdn.ampproject.org/v0/amp-sidebar-0.1.js"></script>
@@ -454,11 +455,13 @@ This sample showcases how to build a product page in AMP HTML.
             [class]="product.selectedColor == 'green' ? 'show' : 'hide'">
       <amp-img src="/img/green_apple_1_1024x682.jpg"
                 width="1024" height="682"
-                layout="responsive">
+                layout="responsive" on="tap:gallery-lightbox"
+                role="button" tabindex="0">
       </amp-img>
       <amp-img src="/img/green_apple_2_1024x685.jpg"
                 width="1024" height="682"
-                layout="responsive">
+                layout="responsive" on="tap:gallery-lightbox"
+                role="button" tabindex="0">
       </amp-img>
     </amp-carousel>
 
@@ -472,7 +475,8 @@ This sample showcases how to build a product page in AMP HTML.
             [class]="product.selectedColor == 'golden' ? 'show' : 'hide'">
         <amp-img src="/img/golden_apple1_1024x682.jpg"
                 width="1024" height="682"
-                layout="responsive">
+                layout="responsive" on="tap:gallery-lightbox"
+                role="button" tabindex="0">
         </amp-img>
     </amp-carousel>
 
@@ -486,13 +490,24 @@ This sample showcases how to build a product page in AMP HTML.
             [class]="product.selectedColor == 'red' ? 'show' : 'hide'">
         <amp-img src="/img/red_apple_1_1024x682.jpg"
                 width="1024" height="682"
-                layout="responsive">
+                layout="responsive" on="tap:gallery-lightbox"
+                role="button" tabindex="0">
         </amp-img>
         <amp-img src="/img/red_apple_2_1024x793.jpg"
                 width="1024" height="682"
-                layout="responsive">
+                layout="responsive" on="tap:gallery-lightbox"
+                role="button" tabindex="0">
         </amp-img>
     </amp-carousel>
+    <!-- ## Full screen image -->
+    <!-- The `amp-image-lightbox` component allows the user to expand an image to fill the viewport.
+    By clicking on each image from the product gallery, the user can see the product image by using the full screen.
+    Learn more [here](https://ampbyexample.com/components/amp-image-lightbox/) -->
+    <amp-image-lightbox id="gallery-lightbox" layout="nodisplay">
+      <div class="lightbox" on="tap:gallery-lightbox.close" role="button"
+          tabindex="0">
+      </div>
+    </amp-lightbox>
 
   </div>
   <!-- ## Product Configuration -->


### PR DESCRIPTION
Related to #578.
Carousel is still not supported on a lightbox (ref [here](https://github.com/ampproject/amphtml/issues/8739)) but we could show how it's possible to add an image lightbox for each product.

@ericlindley-g We briefly talked about this, WDYT?
@sebastianbenz PTAL