### PR TITLE
Remove unused amp-video script inclusion in app-banner example

### DIFF
--- a/src/20_Components/amp-app-banner.html
+++ b/src/20_Components/amp-app-banner.html
@@ -20,7 +20,6 @@
   Import the `amp-app-banner` component.
   -->
   <script async custom-element="amp-app-banner" src="https://cdn.ampproject.org/v0/amp-app-banner-0.1.js"></script>
-  <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
   <!--
     Declare the iOS app in the [meta data](https://developer.apple.com/library/content/documentation/AppleApplications/Reference/SafariWebContent/PromotingAppswithAppBanners/PromotingAppswithAppBanners.html). This enables Safari's build-in app install banner as well.
   -->
@@ -102,8 +101,8 @@ The `amp-app-banner` can be fully customized by the developer as long as the hei
     The amp-app-banner will only show in browsers that don't provide their own app install banner. This means Chrome on Android or Safari on iOS will not show the amp-app-banner, but the native install banner. For testing amp-app-banner you can open this page:
 
   * **On a mobile device:** in browser without native install banner, e.g. [Firefox](https://play.google.com/store/apps/details?id=org.mozilla.firefox&hl=en_GB) on Android or [Chrome](https://itunes.apple.com/gb/app/chrome-web-browser-by-google/id535886823?mt=8) on iOS.
-  * **On Desktop:** in [mobile device emulation mode](https://developers.google.com/web/tools/chrome-devtools/device-mode/) append `#webview=1` to the [page URL](<%host%>/components/amp-app-banner/#webview=1). The other option is to use a custom user agent in mobile emulation mode, for example: 
-  
+  * **On Desktop:** in [mobile device emulation mode](https://developers.google.com/web/tools/chrome-devtools/device-mode/) append `#webview=1` to the [page URL](<%host%>/components/amp-app-banner/#webview=1). The other option is to use a custom user agent in mobile emulation mode, for example:
+
   <pre>Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) CriOS/51.000.21 Mobile/13B143 Safari/601.1</pre>
   -->
 


### PR DESCRIPTION
Just found this while poking around the site. If this should be here, feel free to close.