### PR TITLE
Fixed canonical URL. Added viewport comment.

### DIFF
--- a/src/10_Introduction/Hello_World.html
+++ b/src/10_Introduction/Hello_World.html
@@ -18,7 +18,10 @@ An AMP HTML tutorial - learn the different building blocks of an AMP HTML file. 
   <!--
     AMP HTML files require a canonical link pointing to the regular HTML. If no HTML version exists, it should point to itself.
   -->
-  <link rel="canonical" href="<%host%>/introduction/hello_world">
+  <link rel="canonical" href="<%host%>/introduction/hello_world/">
+  <!--
+    AMP HTML files require a viewport declaration. It's recommended to include initial-scale=1.
+  -->
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <!--
     CSS must be embedded inline.


### PR DESCRIPTION
The canonical URL needs to include a trailing slash, as this is where [/introduction/hello_world/](https://ampbyexample.com/introduction/hello_world/) actually lives.
Additionally, the viewport declaration [is currently not showing](https://ampbyexample.com/introduction/hello_world/), presumably because the comment was missing.