### PR TITLE
Add styles for selected tab

### DIFF
--- a/templates/embed/styles.css
+++ b/templates/embed/styles.css
@@ -28,7 +28,7 @@ a {
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
 }
 ul {
-  padding: 8px;
+  padding: 8px 8px 0;
   margin: 0;
 }
 
@@ -45,13 +45,16 @@ ul {
   display: inline-block;
   list-style: none;
 }
-a[role="tab"]:hover {
-  background: #f4fcfe;
-}
 a[aria-selected], a[role="tab"]:focus {
   position: relative;
   font-weight: bold;
   outline: none;
+}
+a[aria-selected] {
+  border: 1px solid #ddd;
+  border-top: 2px solid #1c79c0;
+  border-bottom: 1px solid #fff;
+  border-radius: 3px 3px 0 0;
 }
 a[role="tab"] {
   color: #333;

--- a/templates/embed/styles.css
+++ b/templates/embed/styles.css
@@ -35,11 +35,11 @@ ul {
 /**
  * Tabs
  */
-[role="tabpanel"] {
-  width: 100%;
-}
 [role="tabpanel"][aria-hidden="true"] {
   display: none;
+}
+ul[role="tablist"] {
+  border-bottom: 1px solid #ddd;
 }
 [role="tablist"] li {
   display: inline-block;
@@ -53,8 +53,14 @@ a[aria-selected], a[role="tab"]:focus {
 a[aria-selected] {
   border: 1px solid #ddd;
   border-top: 2px solid #1c79c0;
-  border-bottom: 1px solid #fff;
+  border-bottom: 1px solid #f5f5f5;
   border-radius: 3px 3px 0 0;
+  background-color: #f5f5f5;
+  margin-bottom: -1px;
+}
+a[aria-selected][aria-control="preview-panel"] {
+  background-color: #fff;
+  border-bottom: 1px solid #fff;
 }
 a[role="tab"] {
   color: #333;
@@ -63,7 +69,10 @@ a[role="tab"] {
   margin-right: 8px;
   padding: 8px;
 }
-
+#source-panel {
+  border: 1px solid #ddd;
+  border-top: 0;
+}
 #preview-panel {
   position: relative;
   height: 110px;
@@ -91,7 +100,6 @@ tt {
   font-size: 14px;
   color: #333;
   background: #f5f5f5;
-  box-shadow: inset 0px 1px 4px #d6d6d6;
   border-radius: 2px;
 }
 


### PR DESCRIPTION
- Added CSS to make tabs appear like tabs
- Fixes https://github.com/ampproject/docs/issues/510.
- Used @morsssss's [code](https://github.com/morsssss/amp-by-example/commit/d6c235b25c50a168cc547d0332feec1ce1baac5f) with a couple tweaks.
- Tested on embedded samples with default active tab of "Source" and specified active tab "Preview'

![tabs-new-look](https://user-images.githubusercontent.com/1012254/27838116-7934d9aa-60b6-11e7-8e02-2a392661873f.jpg)

to: @sebastianbenz, @pbakaus 
