### PR TITLE
Added playlist example for amp-soundcloud

### DIFF
--- a/src/20_Components/amp-soundcloud.html
+++ b/src/20_Components/amp-soundcloud.html
@@ -1,4 +1,4 @@
-<!-- 
+<!--
   ## Introduction
 
   Play soundcloud tracks from within AMP HTML files.
@@ -40,6 +40,14 @@
   <amp-soundcloud height="450"
     layout="fixed-height"
     data-trackid="89299804"
+    data-visual="true"></amp-soundcloud>
+  <!-- ## Playlist Mode -->
+  <!--
+    The playlist mode allows embedding a full Soundcloud playlist by its ID (found in the Soundcloud embed code). The only change is the substitution of `data-trackid` by `data-playlistid`
+  -->
+  <amp-soundcloud height="450"
+    layout="fixed-height"
+    data-playlistid="331919427"
     data-visual="true"></amp-soundcloud>
 </body>
 </html>


### PR DESCRIPTION
### Changes
- Adds an example for the use of `data-playlistid` in `amp-soundcloud`

Closes #886 