### PR TITLE
Update amp-iframe example

### DIFF
--- a/src/20_Components/amp-iframe.html
+++ b/src/20_Components/amp-iframe.html
@@ -29,7 +29,8 @@ div[overflow] {
     scrolled to the top – whichever is smaller. This example might not work depending on your screen
     width. In that case it will only show a loading indicator.
   -->
-  <amp-iframe width="500" height="281"
+  <amp-iframe width="500" title="Netflix House of Cards branding: The Stack"
+                          height="281"
                           layout="responsive"
                           sandbox="allow-scripts allow-same-origin allow-popups"
                           allowfullscreen
@@ -39,7 +40,8 @@ div[overflow] {
 
   <!-- ## Using Placeholders -->
   <!-- The 600px away from the top constraint can be avoided by adding a placeholder image. -->
-  <amp-iframe width="500" height="281"
+  <amp-iframe width="500" title="Netflix House of Cards branding: The Stack"
+                          height="281"
                           layout="responsive"
                           sandbox="allow-scripts allow-same-origin allow-popups"
                           allowfullscreen
@@ -51,7 +53,8 @@ div[overflow] {
   <!-- ## Vimeo -->
   <!-- -->
   <!-- If the video is 600px below the top, no placeholder image is required. -->
-  <amp-iframe width="500" height="281"
+  <amp-iframe width="500" title="Netflix House of Cards branding: The Stack"
+                          height="281"
                           layout="responsive"
                           sandbox="allow-scripts allow-same-origin allow-popups"
                           allowfullscreen
@@ -61,7 +64,8 @@ div[overflow] {
 
   <!-- ## Giphy -->
   <!-- Here is another iframe sample embedding an animated GIF from [Giphy](https://giphy.com). -->
-  <amp-iframe width="600" height="400"
+  <amp-iframe width="600" title="Animated dancing GIF from Giphy"
+                          height="400"
                           layout="responsive"
                           sandbox="allow-scripts allow-same-origin allow-popups"
                           frameborder="0"
@@ -73,7 +77,8 @@ div[overflow] {
     Embedding Google Maps is possible via the [Google Maps Embed API](https://developers.google.com/maps/documentation/embed/guide) and requires
     an [API Key](https://developers.google.com/maps/documentation/embed/guide#api_key). Make sure your API key allows requests from the ampproject.org domain.
   -->
-  <amp-iframe width="600" height="400"
+  <amp-iframe width="600" title="Google map pin on Googleplex, Mountain View CA"
+                          height="400"
                           layout="responsive"
                           sandbox="allow-scripts allow-same-origin allow-popups"
                           frameborder="0"
@@ -104,13 +109,14 @@ div[overflow] {
     2. **Resize on user interaction:** pressing the button will resize the iframe to `300x300`px.
 
   -->
-  <amp-iframe width="150" height="150"
-      sandbox="allow-scripts allow-same-origin"
-      resizable
-      frameborder="0"
-      src="<% api.host %>/iframe/resizable-iframe.html"
-      class="m1">
-    <div overflow tabindex="0" role="button" class="ampstart-card py1" aria-label="Show more">Click to show more</div>
+  <amp-iframe width="150" title="Resizable iframe example from 200x200 to 300x300 "
+                          height="150"
+                          sandbox="allow-scripts allow-same-origin"
+                          resizable
+                          frameborder="0"
+                          src="<% api.host %>/iframe/resizable-iframe.html"
+                          class="m1">
+                          <div overflow tabindex="0" role="button" class="ampstart-card py1" aria-label="Show more">Click to show more</div>
   </amp-iframe>
 
 </body>


### PR DESCRIPTION
PR addresses issue #679 - updating [AMP by Example: amp-iframe component](https://ampbyexample.com/components/amp-iframe/)

I have updated `amp-iframe` example code by adding `title` attribute to all six `amp-iframe` samples.

[W3C H64: Using the `title` attribute of the `frame` and `iframe` elements](https://www.w3.org/TR/WCAG20-TECHS/H64.html): 
"`title` attribute of the `frame` or `iframe` element to describe the contents of each frame. This provides a label for the frame so users can determine which frame to enter and explore in detail. It does not label the individual page (frame) or inline frame (iframe) in the frameset."

[WCAG 2.4.1 Bypass Blocks](https://www.w3.org/TR/2016/NOTE-UNDERSTANDING-WCAG20-20161007/navigation-mechanisms-skip.html): A mechanism is available to bypass blocks of content that are repeated on multiple Web pages. (Level A)