### PR TITLE
Update amp-iframe title attribute: accessibility

### DIFF
--- a/src/30_Advanced/.Implementing_a_video_carousel.html
+++ b/src/30_Advanced/.Implementing_a_video_carousel.html
@@ -29,7 +29,8 @@
     An `amp-carousel` can contain arbitrary content including other AMP components.
   -->
   <amp-carousel layout="responsive" height="480" width="854" type="slides">
-    <amp-iframe width="854" height="480"
+    <amp-iframe title="Netflix House of Cards branding: The Stack"
+                width="854" height="480"
                 layout="responsive"
                 sandbox="allow-scripts allow-same-origin allow-popups allowfullscreen"
                 frameborder="0"


### PR DESCRIPTION
PR addresses issue #679  - updating `<amp-iframe>` example in code base.

I have updated `amp-iframe` example for video carousel by adding `title` attribute.

[W3C H64: Using the title attribute of the frame and iframe elements:](https://www.w3.org/TR/WCAG20-TECHS/H64.html)
"title attribute of the frame or iframe element to describe the contents of each frame. This provides a label for the frame so users can determine which frame to enter and explore in detail. It does not label the individual page (frame) or inline frame (iframe) in the frameset."

[WCAG 2.4.1 Bypass Blocks:](https://www.w3.org/TR/2016/NOTE-UNDERSTANDING-WCAG20-20161007/navigation-mechanisms-skip.html) A mechanism is available to bypass blocks of content that are repeated on multiple Web pages. (Level A)