### PR TITLE
Added title attribute to amp-iframe example

### DIFF
--- a/lib/README.md
+++ b/lib/README.md
@@ -28,7 +28,8 @@ The embed viewer can be configured via get parameters. Currently the following o
 Example embed initially showing the preview tab with a height of 200px (note: the amp-iframe should specify the same height): 
 
 ```
-<amp-iframe height="200"
+<amp-iframe title="Example domain page as a placeholder"
+            height="200"
             layout="fixed-height"
             sandbox="allow-scripts allow-forms allow-same-origin"
             resizable


### PR DESCRIPTION
PR addresses issue #679 - updating `<amp-iframe>` example in code base.

I have added the `title` attribute to the `<amp-iframe>` code in this doc.

[W3C H64: Using the title attribute of the frame and iframe elements](https://www.w3.org/TR/WCAG20-TECHS/H64.html):
"title attribute of the frame or iframe element to describe the contents of each frame. This provides a label for the frame so users can determine which frame to enter and explore in detail. It does not label the individual page (frame) or inline frame (iframe) in the frameset."

[WCAG 2.4.1 Bypass Blocks](https://www.w3.org/TR/2016/NOTE-UNDERSTANDING-WCAG20-20161007/navigation-mechanisms-skip.html): A mechanism is available to bypass blocks of content that are repeated on multiple Web pages. (Level A)