### PR TITLE
Added title attribute to amp-iframe example

### DIFF
--- a/src/30_Advanced/Payments_in_AMP.html
+++ b/src/30_Advanced/Payments_in_AMP.html
@@ -53,13 +53,14 @@ Via [amp-iframe](/components/amp-iframe) and the `allowpaymentrequest` attribute
       2. Passes a relevant product identifier via query string, allowing the iframe to retrive appropriate product information for this product.
 
     -->
-    <amp-iframe width="130" height="42"
-        sandbox="allow-scripts allow-same-origin allow-top-navigation"
-        allowpaymentrequest
-        frameborder="0"
-        src="<% api.host %>/iframe/payments.html?productId=1"
-        class="m1">
-        <button placeholder class="ampstart-btn caps" disabled>Buy Now</button>
+    <amp-iframe title="Buy Now button to retrieve product information"
+                width="130" height="42"
+                sandbox="allow-scripts allow-same-origin allow-top-navigation"
+                allowpaymentrequest
+                frameborder="0"
+                src="<% api.host %>/iframe/payments.html?productId=1"
+                class="m1">
+                <button placeholder class="ampstart-btn caps" disabled>Buy Now</button>
     </amp-iframe>
   </div>
     <!--


### PR DESCRIPTION
PR addresses issue #679  - updating <amp-iframe> example in code base.

I have added the `title` attribute to the`<amp-iframe>` example code.

[W3C H64: Using the title attribute of the frame and iframe elements](https://www.w3.org/TR/WCAG20-TECHS/H64.html):
"title attribute of the frame or iframe element to describe the contents of each frame. This provides a label for the frame so users can determine which frame to enter and explore in detail. It does not label the individual page (frame) or inline frame (iframe) in the frameset."

[WCAG 2.4.1 Bypass Blocks](https://www.w3.org/TR/2016/NOTE-UNDERSTANDING-WCAG20-20161007/navigation-mechanisms-skip.html): A mechanism is available to bypass blocks of content that are repeated on multiple Web pages. (Level A)