### PR TITLE
Added amp-iframe title attribute: accessibility

### DIFF
--- a/src/30_Advanced/Custom_Loading_Indicators.html
+++ b/src/30_Advanced/Custom_Loading_Indicators.html
@@ -56,7 +56,8 @@
 
 <!-- ## Default loading indicator -->
 <!-- While loading content from an endpoint, the default loading indicator (three dots) will be displayed. This iframe takes 5 seconds to be returned by the slow-iframe endpoint. -->
-<amp-iframe width="auto" height="250"
+<amp-iframe title="Displays default loading indicator (three dots) for 5 seconds"
+            width="auto" height="250"
             layout="fixed-height"
             frameborder="0"
             src="<%host%>/samples_templates/slow-iframe/?delay=5000">


### PR DESCRIPTION
PR addresses issue #679  - updating <amp-iframe> example in code base.

Added `title` attribute to this `<amp-iframe>` example code to describe the content of this iframe. 
In this example, "Displays default loading indicator (three dots) for 5 seconds"

[W3C H64: Using the title attribute of the frame and iframe elements:](https://www.w3.org/TR/WCAG20-TECHS/H64.html)
"title attribute of the frame or iframe element to describe the contents of each frame. This provides a label for the frame so users can determine which frame to enter and explore in detail. It does not label the individual page (frame) or inline frame (iframe) in the frameset."

[WCAG 2.4.1 Bypass Blocks:](https://www.w3.org/TR/2016/NOTE-UNDERSTANDING-WCAG20-20161007/navigation-mechanisms-skip.html) A mechanism is available to bypass blocks of content that are repeated on multiple Web pages. (Level A)