### PR TITLE
Added amp-iframe title attribute

### DIFF
--- a/src/20_Components/amp-bind.html
+++ b/src/20_Components/amp-bind.html
@@ -143,13 +143,16 @@
     <!--
       The `src` for iframes embedded with `amp-iframe` can be changed.
     -->
-    <amp-iframe id="amp-iframe" width="500" height="281"
-                            layout="responsive"
-                            sandbox="allow-scripts allow-same-origin allow-popups"
-                            allowfullscreen
-                            frameborder="0"
-                            src="https://player.vimeo.com/video/183849543"
-                            [src]="allAnimals[allAnimals.currentAnimal].iframeUrl">
+    <amp-iframe id="amp-iframe" 
+                title="Cute dog video"
+                width="500" 
+                height="281"
+                layout="responsive"
+                sandbox="allow-scripts allow-same-origin allow-popups"
+                allowfullscreen
+                frameborder="0"
+                src="https://player.vimeo.com/video/183849543"
+                [src]="allAnimals[allAnimals.currentAnimal].iframeUrl">
     </amp-iframe>
 
     <!-- ## Triggering updates -->


### PR DESCRIPTION
PR addresses issue #679 - updating examples in code base:

Added `title` attribute to `<amp-iframe>` example to describe its content:

> Cute dog video

[W3C H64: Using the title attribute of the frame and iframe elements:](https://www.w3.org/TR/WCAG20-TECHS/H64.html)
"title attribute of the frame or iframe element to describe the contents of each frame. This provides a label for the frame so users can determine which frame to enter and explore in detail. It does not label the individual page (frame) or inline frame (iframe) in the frameset."

[WCAG 2.4.1 Bypass Blocks:](https://www.w3.org/TR/2016/NOTE-UNDERSTANDING-WCAG20-20161007/navigation-mechanisms-skip.html) A mechanism is available to bypass blocks of content that are repeated on multiple Web pages. (Level A)