### PR TITLE
Added amp-iframe title attribute & indentation

### DIFF
--- a/src/30_Advanced/Integrating_Videos_in_AMP_an_Overview.html
+++ b/src/30_Advanced/Integrating_Videos_in_AMP_an_Overview.html
@@ -38,7 +38,9 @@
     Use `amp-video` for hosted videos.
     Find more examples [here](/components/amp-video/).
   -->
-  <amp-video width="480" height="270" src="video/tokyo.mp4"
+  <amp-video width="480" 
+             height="270" 
+             src="video/tokyo.mp4"
              poster="/img/tokyo.jpg"
              layout="responsive"
              controls>
@@ -54,8 +56,7 @@
     Use `amp-brightcove` for Brightcove videos.
     Find more examples [here](/components/amp-brightcove/).
   -->
-  <amp-brightcove
-                  data-account="906043040001"
+  <amp-brightcove data-account="906043040001"
                   data-video-id="1401169490001"
                   data-player-id="180a5658-8be8-4f33-8eba-d562ab41b40c"
                   layout="responsive" width="480" height="270">
@@ -65,81 +66,86 @@
     Use `amp-dailymotion` for dailymotion videos.
     Find more examples [here](/components/amp-dailymotion/).
   -->
-  <amp-dailymotion
-    data-videoid="x1r0aw6"
-    layout="responsive"
-    data-ui-highlight="FF4081"
-    width="480" height="270">
+  <amp-dailymotion data-videoid="x1r0aw6"
+                   layout="responsive"
+                   data-ui-highlight="FF4081"
+                   width="480" 
+                   height="270">
   </amp-dailymotion>
   <!-- ### amp-facebook -->
   <!--
     Use `amp-facebook` for Facebook videos.
     Find more examples [here](/components/amp-facebook/).
   -->
-  <amp-facebook width="552" height="310"
-                    layout="responsive"
-                    data-embed-as="video"
-                    data-href="https://www.facebook.com/zuck/videos/10102509264909801/">
+  <amp-facebook width="552" 
+                height="310"
+                layout="responsive"
+                data-embed-as="video"
+                data-href="https://www.facebook.com/zuck/videos/10102509264909801/">
   </amp-facebook>
   <!-- ### amp-instagram -->
   <!--
     Use `amp-instagram` for videos on Instagram.
     Find more examples [here](/components/amp-instagram/).
   -->
-  <amp-instagram
-      data-shortcode="1totVhIFXl"
-      width="1"
-      height="1"
-      layout="responsive">
+  <amp-instagram data-shortcode="1totVhIFXl"
+                 width="1"
+                 height="1"
+                 layout="responsive">
   </amp-instagram>
   <!-- ### amp-twitter -->
   <!--
     Use `amp-twitter` for Twitter videos.
     Find more examples [here](/components/amp-twitter/).
   -->
-  <amp-twitter width="375" height="472"
-    layout="responsive"
-    data-tweetid="707569406105092096">
+  <amp-twitter width="375" 
+               height="472"
+               layout="responsive"
+               data-tweetid="707569406105092096">
   </amp-twitter>
   <!-- ### amp-vimeo -->
   <!--
     Use `amp-vimeo` for Vimeo videos.
     Find more examples [here](/components/amp-vimeo/).
   -->
-  <amp-vimeo
-      data-videoid="27246366"
-      layout="responsive"
-      width="16" height="9">
+  <amp-vimeo data-videoid="27246366"
+             layout="responsive"
+             width="16" height="9">
   </amp-vimeo>
   <!-- ### amp-vine -->
   <!--
     Use `amp-vine` for Vine embeds.
     Find more examples [here](/components/amp-vine/).
   -->
-  <amp-vine width="400" height="400"
-  layout="responsive"
-    data-vineid="MdKjXez002d">
+  <amp-vine width="400" 
+            height="400"
+            layout="responsive"
+            data-vineid="MdKjXez002d">
   </amp-vine>
   <!-- ### amp-youtube -->
   <!--
     Use `amp-youtube` for YouTube videos.
     Find more examples [here](/components/amp-youtube/).
   -->
-  <amp-youtube width="480" height="270"
-                           layout="responsive"
-                           data-videoid="lBTCB7yLs8Y">
+  <amp-youtube width="480"
+               height="270"
+               layout="responsive"
+               data-videoid="lBTCB7yLs8Y">
   </amp-youtube>
   <!-- ## What if your Video Provider is not Supported?-->
   <!--
     Use `amp-iframe` for videos not supported in AMP.
     Find more examples [here](/components/amp-iframe/).
   -->
-  <amp-iframe width="500" height="281"
-                          layout="responsive"
-                          sandbox="allow-scripts allow-same-origin allow-popups"
-                          allowfullscreen
-                          frameborder="0"
-                          src="https://player.ooyala.com/iframe.html?ec=Vxc2k0MDE6Y_C7J5podo3UDxlFxGaZrQ&pbid=6440813504804d76ba35c8c787a4b33c&platform=html5"></amp-iframe>
+  <amp-iframe title="Video of Sintel, an independently produced short film"
+              width="500" 
+              height="281"
+              layout="responsive"
+              sandbox="allow-scripts allow-same-origin allow-popups"
+              allowfullscreen
+              frameborder="0"
+              src="https://player.ooyala.com/iframe.html?ec=Vxc2k0MDE6Y_C7J5podo3UDxlFxGaZrQ&pbid=6440813504804d76ba35c8c787a4b33c&platform=html5">
+  </amp-iframe>
 
 </body>
 </html>


### PR DESCRIPTION
PR addresses issue #679  - updating examples in code base:

1. Added `title` attribute to `<amp-iframe>` example to describe its content.
> Video of Sintel, an independently produced short film

[W3C H64: Using the title attribute of the frame and iframe elements:](https://www.w3.org/TR/WCAG20-TECHS/H64.html)
"title attribute of the frame or iframe element to describe the contents of each frame. This provides a label for the frame so users can determine which frame to enter and explore in detail. It does not label the individual page (frame) or inline frame (iframe) in the frameset."

[WCAG 2.4.1 Bypass Blocks:](https://www.w3.org/TR/2016/NOTE-UNDERSTANDING-WCAG20-20161007/navigation-mechanisms-skip.html) A mechanism is available to bypass blocks of content that are repeated on multiple Web pages. (Level A)

2. Modified indentation for amp components