### PR TITLE
Added amp-iframe title attribute to eCommerce guide

### DIFF
--- a/src/10_Introduction/AMP_for_E-Commerce_Getting_Started.html
+++ b/src/10_Introduction/AMP_for_E-Commerce_Getting_Started.html
@@ -75,8 +75,16 @@
     <div class="ampstart-mobile-frame xs-hide relative">
       <amp-img src="https://ampstart.com/img/www/mobile.svg" width="458" height="806" alt="Mobile outline" layout="responsive" class="absolute top-0 left-0 right-0 bottom-0"></amp-img>
 
-      <amp-iframe width="324" height="494" layout="responsive" sandbox="allow-scripts allow-popups" allowfullscreen="" frameborder="0" src="/samples_templates/product_page/preview/embed/" class="absolute xs-hide">
-      <div placeholder=""></div>
+      <amp-iframe title="AMP ecommerce app, product page"
+		  width="324" 
+		  height="494" 
+		  layout="responsive" 
+		  sandbox="allow-scripts allow-popups" 
+		  allowfullscreen="" 
+		  frameborder="0" 
+		  src="/samples_templates/product_page/preview/embed/" 
+		  class="absolute xs-hide">
+      		  <div placeholder=""></div>
       </amp-iframe>
     </div>
 
@@ -99,8 +107,16 @@
     <div class="ampstart-mobile-frame xs-hide relative">
     <amp-img src="https://ampstart.com/img/www/mobile.svg" width="458" height="806" alt="Mobile outline" layout="responsive" class="absolute top-0 left-0 right-0 bottom-0"></amp-img>
 
-    <amp-iframe width="324" height="494" layout="responsive" sandbox="allow-scripts allow-popups" allowfullscreen="" frameborder="0" src="/samples_templates/product_browse_page/preview/embed/" class="absolute xs-hide">
-    <div placeholder=""></div>
+    <amp-iframe title="AMP ecommerce app, product category page"
+		width="324" 
+		height="494" 
+		layout="responsive" 
+		sandbox="allow-scripts allow-popups" 
+		allowfullscreen="" 
+		frameborder="0" 
+		src="/samples_templates/product_browse_page/preview/embed/" 
+		class="absolute xs-hide">
+    		<div placeholder=""></div>
     </amp-iframe>
     </div>
 


### PR DESCRIPTION
PR addresses issue #679  - updating examples in code base:

Added `title` attribute to both `<amp-iframe>` ecommerce app, product page examples to describe their content.

[W3C H64: Using the title attribute of the frame and iframe elements:](https://www.w3.org/TR/WCAG20-TECHS/H64.html)
"title attribute of the frame or iframe element to describe the contents of each frame. This provides a label for the frame so users can determine which frame to enter and explore in detail. It does not label the individual page (frame) or inline frame (iframe) in the frameset."

[WCAG 2.4.1 Bypass Blocks:](https://www.w3.org/TR/2016/NOTE-UNDERSTANDING-WCAG20-20161007/navigation-mechanisms-skip.html) A mechanism is available to bypass blocks of content that are repeated on multiple Web pages. (Level A)