### PR TITLE
Added amp-iframe title attribute to Video Carousels guide

### DIFF
--- a/src/30_Advanced/Video_Carousels_with_amp-carousel.html
+++ b/src/30_Advanced/Video_Carousels_with_amp-carousel.html
@@ -85,9 +85,13 @@
     <amp-vimeo data-videoid="27246366" width="500" height="281"></amp-vimeo>
     <amp-vine width="400" height="300" layout="responsive" data-vineid="MdKjXez002d"></amp-vine>
     <amp-youtube height="270" layout="fixed-height" data-videoid="SOx1XfOjJPI"></amp-youtube>
-    <amp-iframe width="400" height="300" layout="responsive" sandbox="allow-scripts allow-same-origin allow-popups"
-      allowfullscreen frameborder="0"
-      src="https://player.ooyala.com/iframe.html?ec=Vxc2k0MDE6Y_C7J5podo3UDxlFxGaZrQ&pbid=6440813504804d76ba35c8c787a4b33c&platform=html5">
+    <amp-iframe title="Video of Sintel, an independently produced short film"
+                width="400" 
+                height="300" 
+                layout="responsive" 
+                sandbox="allow-scripts allow-same-origin allow-popups"
+                allowfullscreen frameborder="0"
+                src="https://player.ooyala.com/iframe.html?ec=Vxc2k0MDE6Y_C7J5podo3UDxlFxGaZrQ&pbid=6440813504804d76ba35c8c787a4b33c&platform=html5">
     </amp-iframe>
   </amp-carousel>
 </body>


### PR DESCRIPTION
PR addresses issue #679  - updating examples in code base:

Added `title` attribute to `<amp-iframe>` example to describe its content.

> Video of Sintel, an independently produced short film

[W3C H64: Using the title attribute of the frame and iframe elements:](https://www.w3.org/TR/WCAG20-TECHS/H64.html)
"title attribute of the frame or iframe element to describe the contents of each frame. This provides a label for the frame so users can determine which frame to enter and explore in detail. It does not label the individual page (frame) or inline frame (iframe) in the frameset."

[WCAG 2.4.1 Bypass Blocks:](https://www.w3.org/TR/2016/NOTE-UNDERSTANDING-WCAG20-20161007/navigation-mechanisms-skip.html) A mechanism is available to bypass blocks of content that are repeated on multiple Web pages. (Level A)