### PR TITLE
Added amp-iframe title attribute in News_Archive

### DIFF
--- a/src/50_Samples_%26_Templates/News_Article.html
+++ b/src/50_Samples_%26_Templates/News_Article.html
@@ -209,7 +209,7 @@
       <!-- To achieve its performance, AMP HTML doesn't allow custom Javascript. This doesn't mean that you can't created visually rich and interactive websites with AMP. Embed interactive content via `amp-iframe`. Learn more about `amp-iframe` [here](/components/amp-iframe/).  -->
       <figure>
         <amp-iframe src="https://www.google.us/trends/embed/US_cu_82I1CVMBAACV6M_en/horserace_chart_3c6cdb21-e1eb-4412-9c28-707c3638ea35?hl=en&template=fe"
-
+                    title="Interactive chart displaying 2016 Oscar Best Picture search interest by date"
                     height="360"
                     layout="fixed-height"
                     frameborder="0"


### PR DESCRIPTION
PR addresses issue #679  - updating examples in code base:
Added `title` attribute to `<amp-iframe>` example to describe its content.
> Interactive chart displaying 2016 Oscar Best Picture search interest by date

[W3C H64: Using the title attribute of the frame and iframe elements:](https://www.w3.org/TR/WCAG20-TECHS/H64.html)
"title attribute of the frame or iframe element to describe the contents of each frame. This provides a label for the frame so users can determine which frame to enter and explore in detail. It does not label the individual page (frame) or inline frame (iframe) in the frameset."

[WCAG 2.4.1 Bypass Blocks:](https://www.w3.org/TR/2016/NOTE-UNDERSTANDING-WCAG20-20161007/navigation-mechanisms-skip.html) A mechanism is available to bypass blocks of content that are repeated on multiple Web pages. (Level A)