### PR TITLE
Added amp-iframe title attribute in Housing template

### DIFF
--- a/src/50_Samples_%26_Templates/Housing.html
+++ b/src/50_Samples_%26_Templates/Housing.html
@@ -183,7 +183,8 @@ This sample showcases how to build a housing page in AMP HTML. Explore how to us
         </section>
         <section>
           <h4>View on map</h4>
-          <amp-iframe width="600"
+          <amp-iframe title="Embedded Google map"
+                      width="600"
                       height="400"
                       layout="responsive"
                       sandbox="allow-scripts allow-same-origin allow-popups"


### PR DESCRIPTION
PR addresses issue #679  - updating examples in code base:

Added `title` attribute to `<amp-iframe>` example to describe its content.
> Embedded Google map

[W3C H64: Using the title attribute of the frame and iframe elements:](https://www.w3.org/TR/WCAG20-TECHS/H64.html)
"title attribute of the frame or iframe element to describe the contents of each frame. This provides a label for the frame so users can determine which frame to enter and explore in detail. It does not label the individual page (frame) or inline frame (iframe) in the frameset."

[WCAG 2.4.1 Bypass Blocks:](https://www.w3.org/TR/2016/NOTE-UNDERSTANDING-WCAG20-20161007/navigation-mechanisms-skip.html) A mechanism is available to bypass blocks of content that are repeated on multiple Web pages. (Level A)