### PR TITLE
enable validation for scrollbound tutorial

### DIFF
--- a/src/50_Visual_Effects/Basics_of_scrollbound_effects.html
+++ b/src/50_Visual_Effects/Basics_of_scrollbound_effects.html
@@ -1,6 +1,3 @@
-<!---{
-  "skipValidation": "true"
-}--->
 <!--
   ## Introduction
 


### PR DESCRIPTION
`<amp-animation>` is now valid outdie of `body`, enabling full validation for this sample.