### PR TITLE
controls="controls" now validates

### DIFF
--- a/src/20_Components/amp-video.html
+++ b/src/20_Components/amp-video.html
@@ -25,8 +25,6 @@
     A simple video with controller.
     `amp-video` supports the following formats: mp4, webm, ogg together with all the formats
     supported by the HTML5 video tag including HLS.
-    Boolean attribute (`controls` in this case) must be without values.
-    Expression with value like `controls="controls"` is invalid.
   -->
   <amp-video width="480" height="270" src="/video/tokyo.mp4"
              poster="/img/tokyo.jpg"


### PR DESCRIPTION
Not sure where this changed, but this is now valid. (Tested on https://ampbyexample.com/playground/#url=https%3A%2F%2Fampbyexample.com%2Fcomponents%2Famp-video%2Fsource%2F.)