### PR TITLE
Remove demo from amp-bind

### DIFF
--- a/src/20_Components/amp-bind.html
+++ b/src/20_Components/amp-bind.html
@@ -1,6 +1,3 @@
-<!---{
-    "preview": "default"
-}--->
 <!--
   ## Introduction
 


### PR DESCRIPTION
Using the demo view for this sample is confusing and I think only the view with the explanation should be used. one example of confusion is #1044 