### PR TITLE
Disable preview in Integrating_Videos_in_AMP_an_Overview.html

### DIFF
--- a/src/30_Advanced/Integrating_Videos_in_AMP_an_Overview.html
+++ b/src/30_Advanced/Integrating_Videos_in_AMP_an_Overview.html
@@ -1,6 +1,3 @@
-<!---{
-  "preview": "default"
-  }--->
 <!--
   ## Introduction
 


### PR DESCRIPTION
Starting investigating this as part of #1092 and I think preview does not make sense here. Anyway, the preview is not working at the moment because it's missing a `min-width`, but I would be in favour of removing the preview at all.