### PR TITLE
Rebranding of AMP Ads -> AMPHTML ads

### DIFF
--- a/src/amp-ads/10_Introduction/AMPHTML_ads_vs_non-AMP_ads.html
+++ b/src/amp-ads/10_Introduction/AMPHTML_ads_vs_non-AMP_ads.html
@@ -6,9 +6,9 @@
 <!--
   ## Introduction
 
-  This sample compares the performance of an AMP Ad vs a regular ad. To best compare these two, either view [the demo page](https://ampbyexample-com.cdn.ampproject.org/c/s/ampbyexample.com/amp_ads/amp_ads_vs_non-amp_ads/preview/?exp=a4a:-1) on a mobile device with an active 3G connection or, on desktop, enable <a href="https://developers.google.com/web/tools/chrome-devtools/network-performance/network-conditions">network throttling</a> in Chrome Dev Tools (e.g. "Regular 3G").
+  This sample compares the performance of an AMPHTML ad vs a regular ad. To best compare these two, either view [the demo page](https://ampbyexample-com.cdn.ampproject.org/c/s/ampbyexample.com/amp_ads/amphtml_ads_vs_non-amp_ads/preview/?exp=a4a:-1) on a mobile device with an active 3G connection or, on desktop, enable <a href="https://developers.google.com/web/tools/chrome-devtools/network-performance/network-conditions">network throttling</a> in Chrome Dev Tools (e.g. "Regular 3G").
 
-  An AMP ad is an one where the ad is written in AMP HTML. A valid AMP ad does not contain arbitrary JavaScript. All JavaScript in an AMP ad comes from the open source AMP project which is blessed by the AMP project maintainers. As a result, when an ad is created in AMP, it is always guaranteed to do the right thing from a user experience standpoint.
+  An AMPHTML ad is an one where the ad is written in AMP HTML. A valid AMPHTML ad does not contain arbitrary JavaScript. All JavaScript in an AMPHTML ad comes from the open source AMP project which is blessed by the AMP project maintainers. As a result, when an ad is created in AMP, it is always guaranteed to do the right thing from a user experience standpoint.
 -->
 <!-- -->
 <!doctype html>
@@ -22,14 +22,14 @@
 </head>
 <body>
 
-  <p class="p4">This sample compares the performance of an AMP Ad vs a regular ad. To best compare these two, either view this page on a mobile device with active 3G connection or, if you are on Desktop, enable <a href="https://developers.google.com/web/tools/chrome-devtools/network-performance/network-conditions">network throttling</a> in Chrome Dev Tools (e.g. "Regular 3G").</p>
+  <p class="p4">This sample compares the performance of an AMPHTML ad vs a regular ad. To best compare these two, either view this page on a mobile device with active 3G connection or, if you are on Desktop, enable <a href="https://developers.google.com/web/tools/chrome-devtools/network-performance/network-conditions">network throttling</a> in Chrome Dev Tools (e.g. "Regular 3G").</p>
 
   <div class="flex flex-wrap">
     <div class="ampstart-card my1 mx-auto">
-      <h2 class="p1">AMP Ad</h2>
+      <h2 class="p1">AMPHTML ad</h2>
 
-      <!-- # AMP Ad -->
-      <!-- The ad unit serves an AMP ad profiting from the optimized AMP ad delivery. -->
+      <!-- # AMPHTML ad -->
+      <!-- The ad unit serves an AMPHTML ad profiting from the optimized AMPHTML ad delivery. -->
       <amp-ad data-slot="/30497360/a4a/a4a_native" height="250" type="doubleclick" width="300">
       </amp-ad>
     </div>

--- a/src/amp-ads/10_Introduction/_Hello_World.html
+++ b/src/amp-ads/10_Introduction/_Hello_World.html
@@ -5,10 +5,10 @@
 <!--
   ## Introduction
 
-  An introduction into how to create [AMP Ads](https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/amp-a4a-format.md). AMP Ads are ads implemented using AMPHTML. The AMP Ad runtime is based on the AMP runtime and provides the same performance benefits. However, there are a few things that make them different from normal AMPHTML files.
+  An introduction into how to create [AMPHTML ads](https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/amp-a4a-format.md). AMPHTML ads are ads implemented using AMPHTML. The AMPHTML ads runtime is based on the AMP runtime and provides the same performance benefits. However, there are a few things that make them different from normal AMPHTML files.
 
   <p class="mb2">
-  <div class="p1 ampstart-card abe-info"><strong>Good to know:</strong> the <a href="https://validator.ampproject.org/#htmlFormat=AMP4ADS">AMPHTML Validator</a> features a special validation mode for AMP Ads.
+  <div class="p1 ampstart-card abe-info"><strong>Good to know:</strong> the <a href="https://validator.ampproject.org/#htmlFormat=AMP4ADS">AMPHTML Validator</a> features a special validation mode for AMPHTML ads.
   </div>
   </p>
 -->
@@ -17,18 +17,18 @@
 <!-- -->
 <!-- Doctype declaration is required. -->
 <!doctype html>
-<!-- This tells everyone that this is an AMP for Ads file. -->
+<!-- This tells everyone that this is an AMPHTML ads file. -->
 <html ⚡4ads>
 <!-- ### Head -->
 <!-- -->
 <head>
   <!-- The charset definition must be the first child of the `<head>` tag. -->
   <meta charset="utf-8">
-  <!-- AMP Ads require a custom version of the AMP runtime.-->
+  <!-- AMPHTML ads require a custom version of the AMP runtime.-->
   <script async src="https://cdn.ampproject.org/amp4ads-v0.js"></script>
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <!--
-    The AMP Ad boilerplate which is shorter than the regular AMP boilerplate. -->
+    The AMPHTML ads boilerplate which is shorter than the regular AMP boilerplate. -->
   <style amp4ads-boilerplate>body{visibility:hidden}</style>
   <!--
     CSS must be embedded inline as well.
@@ -43,9 +43,9 @@
 <!-- -->
 <body>
   <!--
-    Inside the body, AMP ads are only allowed to use a restricted set of HTML and AMPHTML elements as described in the [spec](https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/amp-a4a-format.md).
+    Inside the body, AMPHTML ads are only allowed to use a restricted set of HTML and AMPHTML elements as described in the [spec](https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/amp-a4a-format.md).
   -->
   <h1>Hello World</h1>
-<!-- Check out the other [AMP Ad samples](/#amp_ads) to learn how to create more sophisticated AMP Ads. -->
+<!-- Check out the other [AMPHTML ads samples](/#amp_ads) to learn how to create more sophisticated AMPHTML ads. -->
 </body>
 </html>

--- a/src/amp-ads/10_Introduction/index.json
+++ b/src/amp-ads/10_Introduction/index.json
@@ -1,3 +1,3 @@
 {
-  "description": "Getting started with AMP Ads and how they work."
+  "description": "Getting started with AMPHTML ads and how they work."
 }

--- a/src/amp-ads/20_Basic_Ads/Banner_Ad.html
+++ b/src/amp-ads/20_Basic_Ads/Banner_Ad.html
@@ -6,9 +6,9 @@
 <!--
   ## Introduction
 
-  This sample demonstrates how to implement a simple banner [AMP Ad](https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/amp-a4a-format.md). In general an AMP Ad should be a valid AMP document.
+  This sample demonstrates how to implement a simple banner [AMPHTML ad](https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/amp-a4a-format.md). In general an AMPHTML ad should be a valid AMP document.
 
-  The code represents the body that should be returned as a response initiated through an [amp-ad](/components/amp-ad/) component or otherwise whenever we want to return an AMP Ad in any other context.
+  The code represents the body that should be returned as a response initiated through an [amp-ad](/components/amp-ad/) component or otherwise whenever we want to return an AMPHTML ad in any other context.
 
   This example consists of an image and a rendering tracking pixel that are implemented respectively using `amp-img` and `amp-pixel` components.
 -->

--- a/src/amp-ads/20_Basic_Ads/Carousel_Ad.html
+++ b/src/amp-ads/20_Basic_Ads/Carousel_Ad.html
@@ -6,9 +6,9 @@
 <!--
   ## Introduction
 
-  Sample [AMP Ad](https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/amp-a4a-format.md) using `amp-carousel` to display a slide-show style ad. In general an AMP Ad should be a valid AMP document.
+  Sample [AMPHTML ad](https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/amp-a4a-format.md) using `amp-carousel` to display a slide-show style ad. In general an AMPHTML Ad should be a valid AMP document.
 
-  The code represents the body that should be returned as a response initiated through an [amp-ad](/components/amp-ad/) component or otherwise whenever we want to return an AMP Ad in any other context.
+  The code represents the body that should be returned as a response initiated through an [amp-ad](/components/amp-ad/) component or otherwise whenever we want to return an AMPHTML Ad in any other context.
 
   This example displays a set of images forming a slide-show: Every image is clickable. You could build more elaborate slides embedding more AMP components. See [here](/advanced/image_galleries_with_amp-carousel/) or [there](/advanced/video_carousels_with_amp-carousel/).
 

--- a/src/amp-ads/30_Advanced_Ads/Video_Ad.html
+++ b/src/amp-ads/30_Advanced_Ads/Video_Ad.html
@@ -8,9 +8,9 @@
 <!--
   ## Introduction
 
-  Sample [AMP Ad](https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/amp-a4a-format.md) using `amp-video` to display a video ad with layers and playback control.
+  Sample [AMPHTML ad](https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/amp-a4a-format.md) using `amp-video` to display a video ad with layers and playback control.
 
-  The code represents the body that should be returned as a response initiated through an [`amp-ad` component](/components/amp-ad/) or otherwise whenever we want to return an AMP Ad in any other context.
+  The code represents the body that should be returned as a response initiated through an [`amp-ad` component](/components/amp-ad/) or otherwise whenever we want to return an AMPHTML ad in any other context.
 
   AMP provides a basic [action system](https://github.com/ampproject/amphtml/blob/master/spec/amp-actions-and-events.md) to control the page based on user events. This can be used to hide and show elements and to control the playback of the video.
 

--- a/src/amp-ads/40_Experimental_Ads/Carousel_Lightbox_Ad.html
+++ b/src/amp-ads/40_Experimental_Ads/Carousel_Lightbox_Ad.html
@@ -19,7 +19,7 @@
     <style amp4ads-boilerplate>body{visibility:hidden}</style>
     <!-- ## Summary-->
     <!--
-    Sample AMP Ad using [amp-lightbox](https://www.ampproject.org/docs/reference/components/amp-lightbox),
+    Sample AMPHTML ad using [amp-lightbox](https://www.ampproject.org/docs/reference/components/amp-lightbox),
     and [amp-carousel](https://www.ampproject.org/docs/reference/components/amp-carousel) to create an interactive ad.
     -->
     <!-- ## Styling -->

--- a/src/amp-ads/40_Experimental_Ads/Scrollbound_Lightbox_Ad.html
+++ b/src/amp-ads/40_Experimental_Ads/Scrollbound_Lightbox_Ad.html
@@ -20,7 +20,7 @@
     <style amp4ads-boilerplate>body{visibility:hidden}</style>
     <!-- ## Summary-->
     <!--
-    Sample AMP Ad using [amp-lightbox](https://www.ampproject.org/docs/reference/components/amp-lightbox),
+    Sample AMPHTML ad using [amp-lightbox](https://www.ampproject.org/docs/reference/components/amp-lightbox),
     and [amp-animation](https://www.ampproject.org/docs/reference/components/amp-carousel) to create an interactive ad.
     -->
     <!-- ## Styling -->

--- a/src/amp-ads/40_Experimental_Ads/Scrollbound_Slides_360_Ad.html
+++ b/src/amp-ads/40_Experimental_Ads/Scrollbound_Slides_360_Ad.html
@@ -27,7 +27,7 @@
 
   <!-- ## Summary-->
   <!--
-    Sample AMP Ad using [amp-animation](https://www.ampproject.org/docs/reference/components/amp-animation),
+    Sample AMPHTML ad using [amp-animation](https://www.ampproject.org/docs/reference/components/amp-animation),
     [amp-lightbox](https://www.ampproject.org/docs/reference/components/amp-lightbox),
     [amp-google-vrview-image](https://www.ampproject.org/docs/reference/components/amp-google-vrview-image),
     and [amp-img](https://www.ampproject.org/docs/reference/components/amp-img)

--- a/src/amp-ads/40_Experimental_Ads/Scrollbound_Video_Ad.html
+++ b/src/amp-ads/40_Experimental_Ads/Scrollbound_Video_Ad.html
@@ -27,7 +27,7 @@
 
   <!-- ## Summary-->
   <!--
-    Sample AMP Ad using [amp-animation](https://www.ampproject.org/docs/reference/components/amp-animation),
+    Sample AMPHTML ad using [amp-animation](https://www.ampproject.org/docs/reference/components/amp-animation),
     [amp-video](https://www.ampproject.org/docs/reference/components/amp-video) and [amp-img](https://www.ampproject.org/docs/reference/components/amp-img)
     to create an ad that animates based on scrolling.
 

--- a/src/amp-ads/40_Experimental_Ads/Slides_With_Lightbox_Ad.html
+++ b/src/amp-ads/40_Experimental_Ads/Slides_With_Lightbox_Ad.html
@@ -20,7 +20,7 @@
     <style amp4ads-boilerplate>body{visibility:hidden}</style>
     <!-- ## Summary-->
     <!--
-    Sample AMP Ad using [amp-lightbox](https://www.ampproject.org/docs/reference/components/amp-lightbox), [amp-carousel](https://www.ampproject.org/docs/reference/components/amp-carousel) and [amp-bind](https://www.ampproject.org/docs/reference/components/amp-bind) to create an interactive ad.
+    Sample AMPHTML ad using [amp-lightbox](https://www.ampproject.org/docs/reference/components/amp-lightbox), [amp-carousel](https://www.ampproject.org/docs/reference/components/amp-carousel) and [amp-bind](https://www.ampproject.org/docs/reference/components/amp-bind) to create an interactive ad.
     -->
     <!-- ## Styling -->
     <!--

--- a/src/amp-ads/40_Experimental_Ads/Stack_With_Bind_Ad.html
+++ b/src/amp-ads/40_Experimental_Ads/Stack_With_Bind_Ad.html
@@ -18,7 +18,7 @@
     <style amp4ads-boilerplate>body{visibility:hidden}</style>
     <!-- ## Summary-->
     <!--
-    Sample AMP Ad using [amp-bind](https://www.ampproject.org/docs/reference/components/amp-bind),
+    Sample AMPHTML ad using [amp-bind](https://www.ampproject.org/docs/reference/components/amp-bind),
     and [amp-selector](https://www.ampproject.org/docs/reference/components/amp-selector) to create an interactive "stack" ad.
     -->
     <!-- ## Styling -->

--- a/src/amp-ads/40_Experimental_Ads/index.json
+++ b/src/amp-ads/40_Experimental_Ads/index.json
@@ -1,3 +1,3 @@
 {
-  "description": "AMP Ad samples using experimental features demonstrating what is soon going to be possible with the AMP Ad format."
+  "description": "AMPHTML ad samples using experimental features demonstrating what is soon going to be possible with the AMPHTML ad format."
 }

--- a/src/amp-ads/index.json
+++ b/src/amp-ads/index.json
@@ -1,6 +1,6 @@
 {
-  "name": "AMP for Ads",
-  "title": "AMP Ads by Example",
-  "desc": "Learn how to create AMP Ads. AMP Ads are ads built using AMP-HTML and use many of the same AMP components that make AMP pages performant and safe.",
+  "name": "AMPHTML ads",
+  "title": "AMPHTML ads by Example",
+  "desc": "Learn how to create AMPHTML ads. AMPHTML ads are ads built using AMP-HTML and use many of the same AMP components that make AMP pages performant and safe.",
   "index": 1
 }


### PR DESCRIPTION
Changed references of "AMP for Ads" or "AMP Ads" to "AMPHTML ads" per request in https://github.com/ampproject/docs/issues/805.


Fixes: https://github.com/ampproject/docs/issues/805
