### PR TITLE
Add an animation as placeholder for amp-list

### DIFF
--- a/backend/slow-response.go
+++ b/backend/slow-response.go
@@ -17,16 +17,16 @@ package backend
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"strconv"
 	"time"
-	"io/ioutil"
 )
 
 const (
-	SLOW_JSON_SAMPLE_PATH   = "/" + CATEGORY_SAMPLE_TEMPLATES + "/slow-json/"
-	SLOW_JSON_WITH_ITEMS_SAMPLE_PATH   = "/" + CATEGORY_SAMPLE_TEMPLATES + "/slow-json-with-items/"
-	SLOW_IFRAME_SAMPLE_PATH = "/" + CATEGORY_SAMPLE_TEMPLATES + "/slow-iframe/"
+	SLOW_JSON_SAMPLE_PATH            = "/" + CATEGORY_SAMPLE_TEMPLATES + "/slow-json/"
+	SLOW_JSON_WITH_ITEMS_SAMPLE_PATH = "/" + CATEGORY_SAMPLE_TEMPLATES + "/slow-json-with-items/"
+	SLOW_IFRAME_SAMPLE_PATH          = "/" + CATEGORY_SAMPLE_TEMPLATES + "/slow-iframe/"
 )
 
 func InitSlowResponseSample() {
@@ -41,7 +41,7 @@ func prepResponse(w http.ResponseWriter, r *http.Request) {
 	addDelay(r)
 }
 
-func createResponse(responseContent string, r *http.Request) string{
+func createResponse(responseContent string, r *http.Request) string {
 	return fmt.Sprintf(responseContent, getDelay(r))
 }
 
@@ -75,7 +75,7 @@ func readProducts(path string) string {
 		panic(err)
 	}
 	return string(productsFile)
-	}
+}
 
 func slowIframe(w http.ResponseWriter, r *http.Request) {
 	prepResponse(w, r)

--- a/backend/slow-response.go
+++ b/backend/slow-response.go
@@ -64,7 +64,7 @@ func slowJson(w http.ResponseWriter, r *http.Request) {
 }
 
 func slowJsonWithItems(w http.ResponseWriter, r *http.Request) {
-	products := readProducts(DIST_FOLDER + "/json/examples.json")
+	products := readProducts(DIST_FOLDER + "/json/related_products.json")
 	prepResponse(w, r)
 	w.Write([]byte(products))
 }

--- a/src/20_Components/amp-list.html
+++ b/src/20_Components/amp-list.html
@@ -121,10 +121,10 @@
 
   <!-- ## Using a placeholder animation -->
   <!--
-    You can use a custom placeholder like an animation to improve the user experience while the list is loading. In order to
-    see the placeholder, you can toggle a slow 3g network from the Chrome dev console network panel.
+    You can use a custom placeholder like an animation to improve the user experience while the list is loading.
+    We are using an endpoint which intentionally delays the response by 10 seconds.
   -->
-  <amp-list id="amp-list-placeholder" noloading width="auto" height="70" layout="fixed-height" src="http://localhost:8080/samples_templates/slow-json-with-items?delay=10000" template="amp-template-id">
+  <amp-list id="amp-list-placeholder" noloading width="auto" height="70" layout="fixed-height" src="<%host%>/slow-json-with-items?delay=10000" template="amp-template-id">
     <div placeholder class="card">
     </div>
     <template type="amp-mustache">

--- a/src/20_Components/amp-list.html
+++ b/src/20_Components/amp-list.html
@@ -27,7 +27,7 @@
 
   .card {
     width: 100%;
-    height: 70px;
+    height: 120px;
   }
   .card::after {
     content: "";
@@ -37,10 +37,20 @@
     border-radius: 6px;
     -webkit-box-shadow: 0 10px 45px rgba(0, 0, 0, 0.1);
             box-shadow: 0 10px 45px rgba(0, 0, 0, 0.1);
-    background-image: -webkit-gradient(linear, left top, right top, color-stop(0, rgba(211, 211, 211, 0)), color-stop(50%, rgba(211, 211, 211, 0.8)), to(rgba(211, 211, 211, 0))), linear-gradient(white 10px, transparent 0), linear-gradient(white 10px, transparent 0), linear-gradient(lightgrey 70px, transparent 0);
-    background-image: linear-gradient(90deg, rgba(211, 211, 211, 0) 0, rgba(211, 211, 211, 0.8) 50%, rgba(211, 211, 211, 0) 100%), linear-gradient(white 10px, transparent 0), linear-gradient(white 10px, transparent 0), linear-gradient(lightgrey 70px, transparent 0);
-    background-size: 200px 70px, 200px 10px, 200px 10px, 100% 100%;
-    background-position: -150% 0, 10px 10px, 10px 30px, 0 0;
+    background-image: -webkit-gradient(linear, left top, right top, color-stop(0, rgba(211, 211, 211, 0)), color-stop(50%, rgba(211, 211, 211, 0.8)), to(rgba(211, 211, 211, 0))),
+                      linear-gradient(white 10px, transparent 0),
+                      linear-gradient(white 100px, transparent 0),
+                      linear-gradient(white 10px, transparent 0),
+                      linear-gradient(white 10px, transparent 0),
+                      linear-gradient(lightgrey 120px, transparent 0);
+    background-image: linear-gradient(90deg, rgba(211, 211, 211, 0) 0, rgba(211, 211, 211, 0.8) 50%, rgba(211, 211, 211, 0) 100%),
+                      linear-gradient(white 10px, transparent 0),
+                      linear-gradient(white 100px, transparent 0),
+                      linear-gradient(white 10px, transparent 0),
+                      linear-gradient(white 10px, transparent 0),
+                      linear-gradient(lightgrey 120px, transparent 0);
+    background-size: 200px 120px, 100px 10px, 150px 100px, 100px 10px, 100px 10px, 100% 100%;
+    background-position: -150% 0, 200px 10px, 30px 10px, 200px 30px, 200px 50px, 0 0;
     background-repeat: no-repeat;
     -webkit-animation: loading 1.5s infinite;
             animation: loading 1.5s infinite;
@@ -48,19 +58,34 @@
 
   @-webkit-keyframes loading {
     to {
-      background-position: 350% 0, 10px 10px, 10px 30px, 0 0;
+      background-position: 350% 0, 200px 10px, 30px 10px, 200px 30px, 200px 50px, 0 0;
     }
   }
 
   @keyframes loading {
     to {
-      background-position: 350% 0, 10px 10px, 10px 30px, 0 0;
+      background-position: 350% 0, 200px 10px, 30px 10px, 200px 30px, 200px 50px, 0 0;
     }
   }
 
   #amp-list-placeholder div[role=list] {
     margin: 1rem;
   }
+
+    .products {
+      display: block;
+      height: 100px;
+      padding: 0;
+      padding-right: 8px;
+    }
+    .products amp-img {
+      line-height: 24px;
+      font-weight: 400;
+      font-size: 24px;
+      vertical-align: middle;
+      float: left;
+      margin-right: 10px;
+    }
 
   </style>
 </head>
@@ -113,11 +138,21 @@
     You can use a custom placeholder like an animation to improve the user experience while the list is loading.
     We are using an endpoint which intentionally delays the response by 10 seconds.
   -->
-  <amp-list id="amp-list-placeholder" noloading width="auto" height="70" layout="fixed-height" src="<%host%>/slow-json-with-items?delay=10000" template="amp-template-id">
+  <amp-list id="amp-list-placeholder" noloading width="auto"
+            height="600"
+            layout="fixed-height" src="http://localhost:8080/samples_templates/slow-json-with-items/?delay=10000">
     <div placeholder class="card">
     </div>
     <template type="amp-mustache">
-      <div><a href="{{url}}">{{title}}</a></div>
+      <div class="m1 text-decoration-none products">
+        <amp-img width="150"
+                 height="100"
+                 alt="{{name}}"
+                 src="{{img}}"></amp-img>
+               <p class="name">{{name}}</p>
+               <p class="star">{{{stars}}}</p>
+               <p class="price">${{price}}</p>
+      </div>
     </template>
   </amp-list>
 

--- a/src/20_Components/amp-list.html
+++ b/src/20_Components/amp-list.html
@@ -19,26 +19,15 @@
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <style amp-custom>
+
   .list-overflow {
     width: 160px;
     margin-left: auto;
   }
-  :root {
-    --card-padding: 10px;
-    --card-height: 70px;
-    --card-skeleton: linear-gradient(lightgrey var(--card-height), transparent 0);
-    );
-    --title-height: 10px;
-    --title-width: 200px;
-    --title-position: var(--card-padding) var(--card-padding);
-    --title-position2: var(--card-padding) calc(var(--card-padding) *3);
-    --title-skeleton: linear-gradient(white var(--title-height), transparent 0);
-    --blur-width: 200px;
-    --blur-size: var(--blur-width) var(--card-height);
-  }
+
   .card {
     width: 100%;
-    height: var(--card-height);
+    height: 70px;
   }
   .card::after {
     content: "";
@@ -48,10 +37,10 @@
     border-radius: 6px;
     -webkit-box-shadow: 0 10px 45px rgba(0, 0, 0, 0.1);
             box-shadow: 0 10px 45px rgba(0, 0, 0, 0.1);
-    background-image: -webkit-gradient(linear, left top, right top, color-stop(0, rgba(211, 211, 211, 0)), color-stop(50%, rgba(211, 211, 211, 0.8)), to(rgba(211, 211, 211, 0))), var(--title-skeleton), var(--title-skeleton), var(--card-skeleton);
-    background-image: linear-gradient(90deg, rgba(211, 211, 211, 0) 0, rgba(211, 211, 211, 0.8) 50%, rgba(211, 211, 211, 0) 100%), var(--title-skeleton), var(--title-skeleton), var(--card-skeleton);
-    background-size: var(--blur-size), var(--title-width) var(--title-height), var(--title-width) var(--title-height), 100% 100%;
-    background-position: -150% 0, var(--title-position), var(--title-position2), 0 0;
+    background-image: -webkit-gradient(linear, left top, right top, color-stop(0, rgba(211, 211, 211, 0)), color-stop(50%, rgba(211, 211, 211, 0.8)), to(rgba(211, 211, 211, 0))), linear-gradient(white 10px, transparent 0), linear-gradient(white 10px, transparent 0), linear-gradient(lightgrey 70px, transparent 0);
+    background-image: linear-gradient(90deg, rgba(211, 211, 211, 0) 0, rgba(211, 211, 211, 0.8) 50%, rgba(211, 211, 211, 0) 100%), linear-gradient(white 10px, transparent 0), linear-gradient(white 10px, transparent 0), linear-gradient(lightgrey 70px, transparent 0);
+    background-size: 200px 70px, 200px 10px, 200px 10px, 100% 100%;
+    background-position: -150% 0, 10px 10px, 10px 30px, 0 0;
     background-repeat: no-repeat;
     -webkit-animation: loading 1.5s infinite;
             animation: loading 1.5s infinite;
@@ -59,13 +48,13 @@
 
   @-webkit-keyframes loading {
     to {
-      background-position: 350% 0, var(--title-position), var(--title-position2), 0 0;
+      background-position: 350% 0, 10px 10px, 10px 30px, 0 0;
     }
   }
 
   @keyframes loading {
     to {
-      background-position: 350% 0, var(--title-position), var(--title-position2), 0 0;
+      background-position: 350% 0, 10px 10px, 10px 30px, 0 0;
     }
   }
 

--- a/src/20_Components/amp-list.html
+++ b/src/20_Components/amp-list.html
@@ -23,35 +23,51 @@
     width: 160px;
     margin-left: auto;
   }
-  .list-placeholder {
-    width: 10px;
-    height: 10px;
-    background-color: red;
-    position: relative;
-    -webkit-animation-name: example; /* Safari 4.0 - 8.0 */
-    -webkit-animation-duration: 4s; /* Safari 4.0 - 8.0 */
-    -webkit-animation-iteration-count: infinite; /* Safari 4.0 - 8.0 */
-    animation-name: loading-list;
-    animation-duration: 2s;
-    animation-iteration-count: infinite;
+  :root {
+    --card-padding: 10px;
+    --card-height: 48px;
+    --card-skeleton: linear-gradient(lightgrey var(--card-height), transparent 0);
+    );
+    --title-height: 10px;
+    --title-width: 200px;
+    --title-position: var(--card-padding) var(--card-padding);
+    --title-position2: var(--card-padding) calc(var(--card-padding) *3);
+    --title-skeleton: linear-gradient(white var(--title-height), transparent 0);
+    --blur-width: 200px;
+    --blur-size: var(--blur-width) var(--card-height);
+  }
+  .card {
+    width: 100%;
+    height: var(--card-height);
+  }
+  .card::after {
+    content: "";
+    display: block;
+    width: 100%;
+    height: 100%;
+    border-radius: 6px;
+    -webkit-box-shadow: 0 10px 45px rgba(0, 0, 0, 0.1);
+            box-shadow: 0 10px 45px rgba(0, 0, 0, 0.1);
+    background-image: -webkit-gradient(linear, left top, right top, color-stop(0, rgba(211, 211, 211, 0)), color-stop(50%, rgba(211, 211, 211, 0.8)), to(rgba(211, 211, 211, 0))), var(--title-skeleton), var(--title-skeleton), var(--card-skeleton);
+    background-image: linear-gradient(90deg, rgba(211, 211, 211, 0) 0, rgba(211, 211, 211, 0.8) 50%, rgba(211, 211, 211, 0) 100%), var(--title-skeleton), var(--title-skeleton), var(--card-skeleton);
+    background-size: var(--blur-size), var(--title-width) var(--title-height), var(--title-width) var(--title-height), 100% 100%;
+    background-position: -150% 0, var(--title-position), var(--title-position2), 0 0;
+    background-repeat: no-repeat;
+    -webkit-animation: loading 1.5s infinite;
+            animation: loading 1.5s infinite;
   }
 
-    /* Safari 4.0 - 8.0 */
-    @-webkit-keyframes loading-list {
-        0%   {background-color:red; left:0px; top:0px;}
-        25%  {background-color:yellow; left:200px; top:0px;}
-        50%  {background-color:blue; left:200px; top:200px;}
-        75%  {background-color:green; left:0px; top:200px;}
-        100% {background-color:red; left:0px; top:0px;}
+  @-webkit-keyframes loading {
+    to {
+      background-position: 350% 0, var(--title-position), var(--title-position2), 0 0;
     }
+  }
 
-    @keyframes loading-list {
-        0%   {background-color:red; left:0px; top:0px;}
-        25%  {background-color:yellow; left:200px; top:0px;}
-        50%  {background-color:blue; left:200px; top:200px;}
-        75%  {background-color:green; left:0px; top:200px;}
-        100% {background-color:red; left:0px; top:0px;}
+  @keyframes loading {
+    to {
+      background-position: 350% 0, var(--title-position), var(--title-position2), 0 0;
     }
+  }
 
   </style>
 </head>
@@ -101,10 +117,11 @@
 
   <!-- ## Using a placeholder animation -->
   <!--
-    You can use a custom placeholder like an animation to improve the user experience while the list is loading.
+    You can use a custom placeholder like an animation to improve the user experience while the list is loading. In order to
+    see the placeholder, you can toggle a slow 3g network from the Chrome dev console network panel.
   -->
   <amp-list noloading width="auto" height="48" layout="fixed-height" src="<%host%>/json/examples.json" template="amp-template-id" class="m1">
-    <div placeholder class="list-placeholder">
+    <div placeholder class="card">
     </div>
     <template type="amp-mustache">
       <div><a href="{{url}}">{{title}}</a></div>

--- a/src/20_Components/amp-list.html
+++ b/src/20_Components/amp-list.html
@@ -25,67 +25,82 @@
     margin-left: auto;
   }
 
-  .card {
-    width: 100%;
-    height: 120px;
-  }
-  .card::after {
-    content: "";
-    display: block;
-    width: 100%;
-    height: 100%;
-    border-radius: 6px;
-    -webkit-box-shadow: 0 10px 45px rgba(0, 0, 0, 0.1);
-            box-shadow: 0 10px 45px rgba(0, 0, 0, 0.1);
-    background-image: -webkit-gradient(linear, left top, right top, color-stop(0, rgba(211, 211, 211, 0)), color-stop(50%, rgba(211, 211, 211, 0.8)), to(rgba(211, 211, 211, 0))),
-                      linear-gradient(white 10px, transparent 0),
-                      linear-gradient(white 100px, transparent 0),
-                      linear-gradient(white 10px, transparent 0),
-                      linear-gradient(white 10px, transparent 0),
-                      linear-gradient(lightgrey 120px, transparent 0);
-    background-image: linear-gradient(90deg, rgba(211, 211, 211, 0) 0, rgba(211, 211, 211, 0.8) 50%, rgba(211, 211, 211, 0) 100%),
-                      linear-gradient(white 10px, transparent 0),
-                      linear-gradient(white 100px, transparent 0),
-                      linear-gradient(white 10px, transparent 0),
-                      linear-gradient(white 10px, transparent 0),
-                      linear-gradient(lightgrey 120px, transparent 0);
-    background-size: 200px 120px, 100px 10px, 150px 100px, 100px 10px, 100px 10px, 100% 100%;
-    background-position: -150% 0, 200px 10px, 30px 10px, 200px 30px, 200px 50px, 0 0;
-    background-repeat: no-repeat;
-    -webkit-animation: loading 1.5s infinite;
-            animation: loading 1.5s infinite;
-  }
-
-  @-webkit-keyframes loading {
-    to {
-      background-position: 350% 0, 200px 10px, 30px 10px, 200px 30px, 200px 50px, 0 0;
-    }
-  }
-
-  @keyframes loading {
-    to {
-      background-position: 350% 0, 200px 10px, 30px 10px, 200px 30px, 200px 50px, 0 0;
-    }
-  }
-
   #amp-list-placeholder div[role=list] {
     margin: 1rem;
   }
 
-    .products {
+  .products {
       display: block;
       height: 100px;
-      padding: 0;
-      padding-right: 8px;
+      box-shadow: 0 10px 20px rgba(0,0,0,0.19), 0 6px 6px rgba(0,0,0,0.23);
+      background: #fff;
+      border-radius: 2px;
+      margin-bottom: 15px;
+      position: relative;
     }
-    .products amp-img {
-      line-height: 24px;
-      font-weight: 400;
-      font-size: 24px;
-      vertical-align: middle;
+
+  .products amp-img {
       float: left;
-      margin-right: 10px;
+      margin-right: 16px;
+  }
+
+  #amp-list-placeholder ul.results {
+      list-style: none;
+      overflow: auto;
+      margin-left: 1rem;
+      padding: 0;
     }
+
+  #amp-list-placeholder ul.results li {
+         height: 100px;
+         background: #fff;
+         border-radius: 2px;
+         margin-bottom: 15px;
+         position: relative;
+         box-shadow: 0 10px 20px rgba(0,0,0,0.19), 0 6px 6px rgba(0,0,0,0.23);
+  }
+
+  #amp-list-placeholder div[placeholder] ul.results li {
+      background:
+        linear-gradient(90deg, rgba(211, 211, 211, 0) 0, rgba(211, 211, 211, 0.8) 50%, rgba(211, 211, 211, 0) 100%),
+        linear-gradient(#cccccc 100%, transparent 0),
+        linear-gradient(#cccccc 100%, transparent 0),
+        linear-gradient(#cccccc 100%, transparent 0),
+        linear-gradient(#cccccc 100%, transparent 0);
+      background-size:
+        200px 100px,
+        150px 100px,
+        100px 10px,
+        100px 10px,
+        100px 10px;
+      background-position:
+        -150% 0,
+        0 0,
+        166px 4px,
+        166px 29px,
+        166px 53px;
+      background-repeat: no-repeat;
+      -webkit-animation: loading 1.5s infinite;
+      animation: loading 1.5s infinite;
+    }
+
+    @-webkit-keyframes loading {
+      to {
+        background-position: 350% 0, 0 0,
+        166px 4px,
+        166px 29px,
+        166px 53px;
+      }
+    }
+
+     @keyframes loading {
+       to {
+         background-position: 350% 0, 0 0,
+         166px 4px,
+         166px 29px,
+         166px 53px;
+       }
+     }
 
   </style>
 </head>
@@ -140,20 +155,24 @@
   -->
   <amp-list id="amp-list-placeholder" noloading width="auto"
             height="600"
-            layout="fixed-height" src="http://localhost:8080/samples_templates/slow-json-with-items/?delay=10000">
-    <div placeholder class="card">
+            layout="fixed-height" src="<%host%>/samples_templates/slow-json-with-items/?delay=10000">
+    <div placeholder>
+      <ul class="results">
+         <li></li><li></li><li></li><li></li><li></li>
+      </ul>
     </div>
     <template type="amp-mustache">
-      <div class="m1 text-decoration-none products">
-        <amp-img width="150"
-                 height="100"
-                 alt="{{name}}"
-                 src="{{img}}"></amp-img>
-               <p class="name">{{name}}</p>
-               <p class="star">{{{stars}}}</p>
-               <p class="price">${{price}}</p>
-      </div>
+        <div class="products">
+            <amp-img width="150"
+                   height="100"
+                   alt="{{name}}"
+                   src="{{img}}"></amp-img>
+            <p class="name">{{name}}</p>
+            <p class="star">{{{stars}}}</p>
+            <p class="price">${{price}}</p>
+        </div>
     </template>
+
   </amp-list>
 
   <!-- ## Handling List Overflow -->

--- a/src/20_Components/amp-list.html
+++ b/src/20_Components/amp-list.html
@@ -25,7 +25,7 @@
   }
   :root {
     --card-padding: 10px;
-    --card-height: 48px;
+    --card-height: 70px;
     --card-skeleton: linear-gradient(lightgrey var(--card-height), transparent 0);
     );
     --title-height: 10px;
@@ -67,6 +67,10 @@
     to {
       background-position: 350% 0, var(--title-position), var(--title-position2), 0 0;
     }
+  }
+
+  #amp-list-placeholder div[role=list] {
+    margin: 1rem;
   }
 
   </style>
@@ -120,7 +124,7 @@
     You can use a custom placeholder like an animation to improve the user experience while the list is loading. In order to
     see the placeholder, you can toggle a slow 3g network from the Chrome dev console network panel.
   -->
-  <amp-list noloading width="auto" height="48" layout="fixed-height" src="<%host%>/json/examples.json" template="amp-template-id" class="m1">
+  <amp-list id="amp-list-placeholder" noloading width="auto" height="70" layout="fixed-height" src="http://localhost:8080/samples_templates/slow-json-with-items?delay=10000" template="amp-template-id">
     <div placeholder class="card">
     </div>
     <template type="amp-mustache">

--- a/src/20_Components/amp-list.html
+++ b/src/20_Components/amp-list.html
@@ -32,7 +32,7 @@
     -webkit-animation-duration: 4s; /* Safari 4.0 - 8.0 */
     -webkit-animation-iteration-count: infinite; /* Safari 4.0 - 8.0 */
     animation-name: loading-list;
-    animation-duration: 4s;
+    animation-duration: 2s;
     animation-iteration-count: infinite;
   }
 
@@ -103,7 +103,7 @@
   <!--
     You can use a custom placeholder like an animation to improve the user experience while the list is loading.
   -->
-  <amp-list width="auto" height="48" layout="fixed-height" src="<%host%>/json/examples.json" template="amp-template-id" class="m1">
+  <amp-list noloading width="auto" height="48" layout="fixed-height" src="<%host%>/json/examples.json" template="amp-template-id" class="m1">
     <div placeholder class="list-placeholder">
     </div>
     <template type="amp-mustache">

--- a/src/20_Components/amp-list.html
+++ b/src/20_Components/amp-list.html
@@ -23,6 +23,36 @@
     width: 160px;
     margin-left: auto;
   }
+  .list-placeholder {
+    width: 10px;
+    height: 10px;
+    background-color: red;
+    position: relative;
+    -webkit-animation-name: example; /* Safari 4.0 - 8.0 */
+    -webkit-animation-duration: 4s; /* Safari 4.0 - 8.0 */
+    -webkit-animation-iteration-count: infinite; /* Safari 4.0 - 8.0 */
+    animation-name: loading-list;
+    animation-duration: 4s;
+    animation-iteration-count: infinite;
+  }
+
+    /* Safari 4.0 - 8.0 */
+    @-webkit-keyframes loading-list {
+        0%   {background-color:red; left:0px; top:0px;}
+        25%  {background-color:yellow; left:200px; top:0px;}
+        50%  {background-color:blue; left:200px; top:200px;}
+        75%  {background-color:green; left:0px; top:200px;}
+        100% {background-color:red; left:0px; top:0px;}
+    }
+
+    @keyframes loading-list {
+        0%   {background-color:red; left:0px; top:0px;}
+        25%  {background-color:yellow; left:200px; top:0px;}
+        50%  {background-color:blue; left:200px; top:200px;}
+        75%  {background-color:green; left:0px; top:200px;}
+        100% {background-color:red; left:0px; top:0px;}
+    }
+
   </style>
 </head>
 <body>
@@ -67,6 +97,18 @@
   -->
   <amp-list width="auto" height="100" layout="fixed-height" src="<%host%>/json/examples.json"
       template="amp-template-id" class="m1">
+  </amp-list>
+
+  <!-- ## Using a placeholder animation -->
+  <!--
+    You can use a custom placeholder like an animation to improve the user experience while the list is loading.
+  -->
+  <amp-list width="auto" height="48" layout="fixed-height" src="<%host%>/json/examples.json" template="amp-template-id" class="m1">
+    <div placeholder class="list-placeholder">
+    </div>
+    <template type="amp-mustache">
+      <div><a href="{{url}}">{{title}}</a></div>
+    </template>
   </amp-list>
 
   <!-- ## Handling List Overflow -->

--- a/static/sw.js
+++ b/static/sw.js
@@ -24,6 +24,7 @@ const IGNORED_URLS = [
   /.*\/shopping_cart$/,
   /.*\/favorite$/,
   /.*\/favorite-with-count$/,
+  /.*\/slow-json-with-items$/
 ];
 
 config.filesToCache = [
@@ -41,7 +42,8 @@ config.filesToCache = [
  * Generates a placeholder SVG image of the given size.
  */
 function offlineImage(name, width, height) {
-  return `<?xml version="1.0"?>
+  return
+    `<?xml version="1.0"?>
 <svg width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" xmlns="http://www.w3.org/2000/svg" version="1.1">
   <g fill="none" fill-rule="evenodd"><path fill="#F8BBD0" d="M0 0h${width}v${height}H0z"/></g>
   <text text-anchor="middle" x="${Math.floor(width / 2)}" y="${Math.floor(height / 2)}">image offline (${name})</text>
@@ -94,9 +96,11 @@ function ampByExampleHandler(request, values) {
       const url = request.url;
       const fileName = url.substring(url.lastIndexOf('/') + 1);
       // TODO use correct image dimensions
-      return new Response(offlineImage(fileName, 1080, 610),
-          { headers: { 'Content-Type': 'image/svg+xml' } }
-      );
+      return new Response(offlineImage(fileName, 1080, 610), {
+        headers: {
+          'Content-Type': 'image/svg+xml'
+        }
+      });
     });
   } else {
     // cache first for all other requests
@@ -114,9 +118,13 @@ function shouldNotCache(request) {
 
 toolbox.options.debug = false;
 toolbox.router.default = toolbox.networkFirst;
-toolbox.router.get('/(.*)', ampByExampleHandler, {origin: self.location.origin});
+toolbox.router.get('/(.*)', ampByExampleHandler, {
+  origin: self.location.origin
+});
 // network first amp runtime
-toolbox.router.get('/(.*)', toolbox.networkFirst, {origin: 'https://cdn.ampproject.org'});
+toolbox.router.get('/(.*)', toolbox.networkFirst, {
+  origin: 'https://cdn.ampproject.org'
+});
 
 toolbox.precache(config.filesToCache);
 
@@ -124,7 +132,9 @@ toolbox.precache(config.filesToCache);
 // "first" page the user visits is only cached on the second visit,
 // since the first load is uncontrolled.
 toolbox.precache(
-  clients.matchAll({includeUncontrolled: true}).then(l => {
+  clients.matchAll({
+    includeUncontrolled: true
+  }).then(l => {
     return l.map(c => c.url);
   })
 );


### PR DESCRIPTION
Add an animation as placeholder for amp-list.
@aghassemi not sure what I am doing wrong but I still see the default placeholder "..." of `amp-list`, is it possible to overwrite it with a custom animation?