### PR TITLE
Update amp-date-picker doc to match json file

### DIFF
--- a/src/20_Components/amp-date-picker.html
+++ b/src/20_Components/amp-date-picker.html
@@ -195,7 +195,7 @@
 ```
     {
       "templates": [{
-      "id": "low",
+      "id": "spooky",
       "dates": [
         "2017-11-01", "2017-11-03", "2017-11-05", "2017-11-06",
         "FREQ=WEEKLY;DTSTART=20171101T150000Z;COUNT=30;WKST=MO;BYDAY=TU,SA"


### PR DESCRIPTION
Solves #1059 
This fixes the doc using the right id string used in the code.

@lswang1618 Thanks for spotting it! 