### PR TITLE
Fix layout on paged_list

### DIFF
--- a/src/30_Advanced/Paged_List.html
+++ b/src/30_Advanced/Paged_List.html
@@ -140,7 +140,7 @@
     <div class="items">
       {{#products}}
       <div class="item">
-        <amp-img class="image" width="320" height="240" src="{{image}}"></amp-img>
+        <amp-img layout="responsive" class="image" width="320" height="240" src="{{image}}"></amp-img>
         <strong class="title">{{title}}</strong>
         <p class="copy">{{copy}}</p>
       </div>


### PR DESCRIPTION
Fixes #1096 
This is working on large screens but not on small screens. The responsive layout will make the img smaller.