### PR TITLE
Fix  clear action for date-picker

### DIFF
--- a/src/20_Components/amp-date-picker.html
+++ b/src/20_Components/amp-date-picker.html
@@ -68,6 +68,8 @@
     have been set with `AMP.setState`.
     A placeholder is required for the component. For a single date, this can take the form:
     `<input amp-date-placeholder placeholder="Pick a date"/>`.
+    `amp-date-picker` introduces the `clear` action that can be called after clicking on a button to clear the date selection;
+    it requires the `show-clear-date` attribute.
   -->
   <div>
     <button class="ampstart-btn m1 caps" on="tap:simple-date-picker.clear">Clear</button>

--- a/src/20_Components/amp-date-picker.html
+++ b/src/20_Components/amp-date-picker.html
@@ -96,7 +96,7 @@
     could be dates of the month where the price of an item is fixed to a specific number.
   -->
   <div>
-    <button class="ampstart-btn m1 caps" on="tap:simple-date-picker.clear">Clear</button>
+    <button class="ampstart-btn m1 caps" on="tap:simple-date-picker-2.clear">Clear</button>
     <amp-date-picker
       type="single"
       layout="container"
@@ -133,7 +133,7 @@
     The `highlighted` attributes a space separated list of ISO 8601 dates and RFC 5545 RRULEs specifying dates displayed with a highlight style.
   -->
   <div>
-    <button class="ampstart-btn m1 caps" on="tap:simple-date-picker.clear">Clear</button>
+    <button class="ampstart-btn m1 caps" on="tap:simple-date-picker-3.clear">Clear</button>
     <amp-date-picker
       type="single"
       layout="container"


### PR DESCRIPTION
The clear action is currently referring to the same date-picker for 3 different samples. I updated the action using the right id.
@sebastianbenz PTAL

Related to #1059 