### PR TITLE
Remove amp-ima-video experimental tag.

### DIFF
--- a/src/20_Components/amp-ima-video.html
+++ b/src/20_Components/amp-ima-video.html
@@ -1,6 +1,3 @@
-<!---{
-  "experiments": ["amp-ima-video"]
-}--->
 <!--
   ## Introduction
 


### PR DESCRIPTION
amp-ima-video is no longer in an experimental state.