### PR TITLE
Add title to all samples

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -356,7 +356,7 @@ gulp.task('create', 'create a new AMP example', function() {
   return file(examplePath, '', {
       src: true
     })
-    .pipe(createExample(config))
+    .pipe(createExample(paths, config))
     .pipe(gulp.dest(paths.src));
 });
 
@@ -541,14 +541,13 @@ function generateRobotsTxt(contents) {
     .pipe(gulp.dest('dist'));
 }
 
-/* adds a canonical link to sample files */
+/* adds a title link to all sample files */
 function performChange(content) {
   const exampleFile = ExampleFile.fromPath(this.file.path);
   const canonical = config.host + exampleFile.url();
-  if (!/<link rel="canonical"/.test(content)) {
+  if (!/<title>/.test(content)) {
     content = content.replace(/<meta charset="utf-8">/g,
-      '<meta charset="utf-8">\n  <link rel="canonical" href="' + canonical +
-      '">');
+      '<meta charset="utf-8">\n  <title>' + exampleFile.title() + '</title>');
     gutil.log("updating canonical: " + this.file.relative);
   }
   return content;

--- a/src/10_Introduction/AMP_for_E-Commerce_Getting_Started.html
+++ b/src/10_Introduction/AMP_for_E-Commerce_Getting_Started.html
@@ -5,6 +5,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>AMP for E-Commerce Getting Started</title>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <link rel="canonical" href="<%host%>/introduction/amp_for_e-commerce_getting_started/">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">

--- a/src/10_Introduction/Internationalization.html
+++ b/src/10_Introduction/Internationalization.html
@@ -8,6 +8,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>Internationalization</title>
   <link rel="canonical" href="<%host%>/introduction/internationalization/">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/10_Introduction/_Hello_World.html
+++ b/src/10_Introduction/_Hello_World.html
@@ -13,6 +13,7 @@ An AMP HTML tutorial - learn the different building blocks of an AMP HTML file. 
 <head>
   <!-- The charset definition must be the first child of the `<head>` tag. -->
   <meta charset="utf-8">
+  <title> Hello World</title>
   <!-- The AMP runtime must be loaded as the second child of the `<head>` tag.-->
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <!--

--- a/src/10_Introduction/_How_to_publish_AMPs.html
+++ b/src/10_Introduction/_How_to_publish_AMPs.html
@@ -7,6 +7,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title> How to publish AMPs</title>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <link rel="canonical" href="<%host%>/introduction/how_to_publish_amps/">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">

--- a/src/20_Components/amp-access-laterpay.html
+++ b/src/20_Components/amp-access-laterpay.html
@@ -8,6 +8,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-access-laterpay</title>
   <link rel="canonical" href="<%host%>/components/amp-access-laterpay/" >
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/20_Components/amp-access.html
+++ b/src/20_Components/amp-access.html
@@ -8,6 +8,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-access</title>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 
   <!-- ## Setup -->

--- a/src/20_Components/amp-accordion.html
+++ b/src/20_Components/amp-accordion.html
@@ -8,6 +8,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-accordion</title>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <!-- ## Setup -->
   <!--

--- a/src/20_Components/amp-ad.html
+++ b/src/20_Components/amp-ad.html
@@ -9,6 +9,7 @@
 
 <head>
   <meta charset="utf-8">
+  <title>amp-ad</title>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <!-- ## Setup -->
   <!-- Import the `amp-ad` component in the header. -->

--- a/src/20_Components/amp-analytics.html
+++ b/src/20_Components/amp-analytics.html
@@ -16,6 +16,7 @@ This sample demonstrates which events can be measured and how they can be config
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-analytics</title>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <!-- ## Setup -->
   <!--  Import the amp-analytics component in the header. -->

--- a/src/20_Components/amp-anim.html
+++ b/src/20_Components/amp-anim.html
@@ -8,6 +8,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-anim</title>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <!-- ## Setup -->
   <!--

--- a/src/20_Components/amp-app-banner.html
+++ b/src/20_Components/amp-app-banner.html
@@ -14,6 +14,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-app-banner</title>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <!-- ## Setup -->
   <!--

--- a/src/20_Components/amp-audio.html
+++ b/src/20_Components/amp-audio.html
@@ -8,6 +8,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-audio</title>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <!-- ## Setup -->
   <!--

--- a/src/20_Components/amp-bind.html
+++ b/src/20_Components/amp-bind.html
@@ -19,6 +19,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-bind</title>
   <link rel="canonical" href="<%host%>/components/amp-bind/">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/20_Components/amp-brid-player.html
+++ b/src/20_Components/amp-brid-player.html
@@ -8,6 +8,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-brid-player</title>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <!-- ## Setup -->
   <!--

--- a/src/20_Components/amp-brightcove.html
+++ b/src/20_Components/amp-brightcove.html
@@ -10,6 +10,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-brightcove</title>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <!-- ## Setup -->
   <!-- Import the Brightcove component in the header. -->

--- a/src/20_Components/amp-call-tracking.html
+++ b/src/20_Components/amp-call-tracking.html
@@ -8,6 +8,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-call-tracking</title>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <!-- ## Setup -->
   <!--

--- a/src/20_Components/amp-carousel.html
+++ b/src/20_Components/amp-carousel.html
@@ -9,6 +9,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-carousel</title>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <!-- ## Setup -->
   <!-- Import the carousel component in the header. -->

--- a/src/20_Components/amp-dailymotion.html
+++ b/src/20_Components/amp-dailymotion.html
@@ -8,6 +8,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-dailymotion</title>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <!-- ## Setup -->
   <!--

--- a/src/20_Components/amp-dynamic-css-classes.html
+++ b/src/20_Components/amp-dynamic-css-classes.html
@@ -2,6 +2,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-dynamic-css-classes</title>
   <!-- #### Introduction 
      AMP's dynamic CSS classes provided by the <a href="https://www.ampproject.org/docs/reference/components/presentation/amp-dynamic-css-classes">amp-dynamic-css-class tag</a> enable boolean logic for a handful of conditions 
   -->

--- a/src/20_Components/amp-experiment.html
+++ b/src/20_Components/amp-experiment.html
@@ -10,6 +10,7 @@ In this sample, we're using Google Analytics to track the experiment. Google Ana
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-experiment</title>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
    <!-- ## Setup -->
   <!--

--- a/src/20_Components/amp-facebook.html
+++ b/src/20_Components/amp-facebook.html
@@ -8,6 +8,7 @@
 <html ⚡>
   <head>
     <meta charset="utf-8">
+  <title>amp-facebook</title>
     <script async src="https://cdn.ampproject.org/v0.js"></script>
     <!-- ## Setup -->
     <!-- Import the amp-facebook component -->

--- a/src/20_Components/amp-fit-text.html
+++ b/src/20_Components/amp-fit-text.html
@@ -13,6 +13,7 @@
   -->
   <script async custom-element="amp-fit-text" src="https://cdn.ampproject.org/v0/amp-fit-text-0.1.js"></script>
   <meta charset="utf-8">
+  <title>amp-fit-text</title>
   <link rel="canonical" href="<%host%>/components/amp-fit-text/">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>

--- a/src/20_Components/amp-font.html
+++ b/src/20_Components/amp-font.html
@@ -9,6 +9,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-font</title>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <!-- ## Setup -->
   <!--

--- a/src/20_Components/amp-form.html
+++ b/src/20_Components/amp-form.html
@@ -14,6 +14,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-form</title>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <!-- ## Setup -->
   <!--

--- a/src/20_Components/amp-fx-flying-carpet.html
+++ b/src/20_Components/amp-fx-flying-carpet.html
@@ -10,6 +10,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-fx-flying-carpet</title>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <!-- ## Setup -->
   <!-- Import the `amp-fx-flying-carpet` component in the header. -->

--- a/src/20_Components/amp-fx-parallax.html
+++ b/src/20_Components/amp-fx-parallax.html
@@ -20,6 +20,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-fx-parallax</title>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <!-- #### Setup -->
   <!--

--- a/src/20_Components/amp-gfycat.html
+++ b/src/20_Components/amp-gfycat.html
@@ -9,6 +9,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-gfycat</title>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <!-- ## Setup -->
   <!--

--- a/src/20_Components/amp-gist.html
+++ b/src/20_Components/amp-gist.html
@@ -10,6 +10,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-gist</title>
   <link rel="canonical" href="<%host%>/components/amp-gist/">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/20_Components/amp-google-vrview-image.html
+++ b/src/20_Components/amp-google-vrview-image.html
@@ -21,6 +21,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-google-vrview-image</title>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <!-- ## Setup -->
   <!--

--- a/src/20_Components/amp-hulu.html
+++ b/src/20_Components/amp-hulu.html
@@ -8,6 +8,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-hulu</title>
   <link rel="canonical" href="<%host%>/components/amp-hulu/">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/20_Components/amp-iframe.html
+++ b/src/20_Components/amp-iframe.html
@@ -8,6 +8,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-iframe</title>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <!--  Import the amp-iframe component in the header. -->
   <script async custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js"></script>

--- a/src/20_Components/amp-ima-video.html
+++ b/src/20_Components/amp-ima-video.html
@@ -13,6 +13,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-ima-video</title>
   <link rel="canonical" href="<%host%>/components/amp-ima-video/">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/20_Components/amp-image-lightbox.html
+++ b/src/20_Components/amp-image-lightbox.html
@@ -8,6 +8,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-image-lightbox</title>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <!-- ## Setup -->
   <!-- Import the amp-image-lightbox component in the header -->

--- a/src/20_Components/amp-img.html
+++ b/src/20_Components/amp-img.html
@@ -9,6 +9,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-img</title>
   <!-- ## Setup -->
   <!--
     `amp-img` is a built-in element and is automatically imported via the AMP runtime.

--- a/src/20_Components/amp-instagram.html
+++ b/src/20_Components/amp-instagram.html
@@ -8,6 +8,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-instagram</title>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <link rel="canonical" href="<%host%>/components/amp-instagram/">
   <!-- ## Setup -->

--- a/src/20_Components/amp-install-serviceworker.html
+++ b/src/20_Components/amp-install-serviceworker.html
@@ -17,6 +17,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-install-serviceworker</title>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <!-- ## Setup -->
   <!--

--- a/src/20_Components/amp-jwplayer.html
+++ b/src/20_Components/amp-jwplayer.html
@@ -8,6 +8,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-jwplayer</title>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <!-- ## Setup -->
   <!--

--- a/src/20_Components/amp-kaltura-player.html
+++ b/src/20_Components/amp-kaltura-player.html
@@ -8,6 +8,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-kaltura-player</title>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <!-- ## Setup -->
   <!--

--- a/src/20_Components/amp-lightbox.html
+++ b/src/20_Components/amp-lightbox.html
@@ -9,6 +9,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-lightbox</title>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <!-- ## Setup -->
   <!-- Import the amp-lightbox component in the header -->

--- a/src/20_Components/amp-list.html
+++ b/src/20_Components/amp-list.html
@@ -8,6 +8,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-list</title>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <!-- ## Setup -->
   <!-- Import the `amp-list` component ... -->

--- a/src/20_Components/amp-live-list.html
+++ b/src/20_Components/amp-live-list.html
@@ -11,6 +11,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-live-list</title>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <!-- ## Setup -->
   <!--

--- a/src/20_Components/amp-mustache.html
+++ b/src/20_Components/amp-mustache.html
@@ -10,6 +10,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-mustache</title>
   <link rel="canonical" href="<%host%>/components/amp-mustache/">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/20_Components/amp-o2-player.html
+++ b/src/20_Components/amp-o2-player.html
@@ -10,6 +10,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-o2-player</title>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <!-- ## Setup -->
   <!--

--- a/src/20_Components/amp-pinterest.html
+++ b/src/20_Components/amp-pinterest.html
@@ -8,6 +8,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-pinterest</title>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <!-- ## Setup -->
   <!--

--- a/src/20_Components/amp-pixel.html
+++ b/src/20_Components/amp-pixel.html
@@ -13,6 +13,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-pixel</title>
   <link rel="canonical" href="<%host%>/components/amp-pixel/">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/20_Components/amp-reach-player.html
+++ b/src/20_Components/amp-reach-player.html
@@ -8,6 +8,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-reach-player</title>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <!-- ## Setup -->
   <!--

--- a/src/20_Components/amp-selector.html
+++ b/src/20_Components/amp-selector.html
@@ -8,6 +8,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-selector</title>
   <link rel="canonical" href="<%host%>/components/amp-selector/">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/20_Components/amp-sidebar.html
+++ b/src/20_Components/amp-sidebar.html
@@ -18,6 +18,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-sidebar</title>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <!-- ## Setup -->
   <!--

--- a/src/20_Components/amp-social-share.html
+++ b/src/20_Components/amp-social-share.html
@@ -8,6 +8,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-social-share</title>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <!-- ## Setup -->
   <!--

--- a/src/20_Components/amp-soundcloud.html
+++ b/src/20_Components/amp-soundcloud.html
@@ -8,6 +8,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-soundcloud</title>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <!-- ## Setup -->
   <!--

--- a/src/20_Components/amp-springboard-player.html
+++ b/src/20_Components/amp-springboard-player.html
@@ -8,6 +8,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-springboard-player</title>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <!-- ## Setup -->
   <!--

--- a/src/20_Components/amp-sticky-ad.html
+++ b/src/20_Components/amp-sticky-ad.html
@@ -11,6 +11,7 @@
 
 <head>
   <meta charset="utf-8">
+  <title>amp-sticky-ad</title>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <!--
     Import the `amp-sticky-ad` component in the header.

--- a/src/20_Components/amp-timeago.html
+++ b/src/20_Components/amp-timeago.html
@@ -8,6 +8,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-timeago</title>
   <link rel="canonical" href="<%host%>/../components/amp-timeago/">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/20_Components/amp-twitter.html
+++ b/src/20_Components/amp-twitter.html
@@ -8,6 +8,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-twitter</title>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <!-- ## Setup -->
   <!-- Don't forget to import the twitter component -->

--- a/src/20_Components/amp-user-notification.html
+++ b/src/20_Components/amp-user-notification.html
@@ -9,6 +9,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-user-notification</title>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <!-- ## Setup -->
   <!-- Import `amp-user-notification` in the header. -->

--- a/src/20_Components/amp-video.html
+++ b/src/20_Components/amp-video.html
@@ -8,6 +8,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-video</title>
   <!-- ## Setup -->
   <!--
     Import the `amp-video` component.

--- a/src/20_Components/amp-vimeo.html
+++ b/src/20_Components/amp-vimeo.html
@@ -8,6 +8,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-vimeo</title>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <!-- ## Setup -->
   <!--

--- a/src/20_Components/amp-vine.html
+++ b/src/20_Components/amp-vine.html
@@ -8,6 +8,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-vine</title>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <!-- ## Setup -->
   <!--

--- a/src/20_Components/amp-youtube.html
+++ b/src/20_Components/amp-youtube.html
@@ -8,6 +8,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-youtube</title>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <!-- ## Setup -->
   <!-- Import the amp-youtube component -->

--- a/src/30_Advanced/Click-to-play_overlay_for_amp-video.html
+++ b/src/30_Advanced/Click-to-play_overlay_for_amp-video.html
@@ -14,6 +14,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>Click-to-play overlay for amp-video</title>
   <!-- ## Setup -->
   <!--
     Import the `amp-video` component.

--- a/src/30_Advanced/Custom_Loading_Indicators.html
+++ b/src/30_Advanced/Custom_Loading_Indicators.html
@@ -8,6 +8,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>Custom Loading Indicators</title>
   <link rel="canonical" href="<%host%>/advanced/custom_loading_indicators/">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/30_Advanced/How_to_support_Images_with_unknown_Dimensions%3F.html
+++ b/src/30_Advanced/How_to_support_Images_with_unknown_Dimensions%3F.html
@@ -2,6 +2,7 @@
 <html amp lang="en">
   <head>
     <meta charset="utf-8">
+  <title>How to support Images with unknown Dimensions?</title>
     <script async src="https://cdn.ampproject.org/v0.js"></script>
     <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>
     <link rel="canonical" href="<%host%>/advanced/how_to_support_images_with_unknown_dimensions/">

--- a/src/30_Advanced/Image_Galleries_with_amp-carousel.html
+++ b/src/30_Advanced/Image_Galleries_with_amp-carousel.html
@@ -11,6 +11,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>Image Galleries with amp-carousel</title>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <!-- ## Setup -->
   <!-- Import the carousel component in the header. -->

--- a/src/30_Advanced/Integrating_Videos_in_AMP_an_Overview.html
+++ b/src/30_Advanced/Integrating_Videos_in_AMP_an_Overview.html
@@ -9,6 +9,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>Integrating Videos in AMP an Overview</title>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <!-- ## Setup -->
   <!--

--- a/src/30_Advanced/Layout_System.html
+++ b/src/30_Advanced/Layout_System.html
@@ -10,6 +10,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>Layout System</title>
   <link rel="canonical" href="<%host%>/advanced/layout_system/" >
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <meta name="amp-experiment-token" content="HfmyLgNLmblRg3Alqy164Vywr">

--- a/src/30_Advanced/Long_List_of_amp-instagram_Embeds.html
+++ b/src/30_Advanced/Long_List_of_amp-instagram_Embeds.html
@@ -8,6 +8,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>Long List of amp-instagram Embeds</title>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <!-- ## Setup -->
   <!-- Import the amp-instagram component in the header -->

--- a/src/30_Advanced/Payments_in_AMP.html
+++ b/src/30_Advanced/Payments_in_AMP.html
@@ -14,6 +14,7 @@ Via [amp-iframe](/components/amp-iframe) and the `allowpaymentrequest` attribute
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>Payments in AMP</title>
   <link rel="canonical" href="<%host%>/advanced/payments_iframe/">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/30_Advanced/Rich_Media_Notifications.html
+++ b/src/30_Advanced/Rich_Media_Notifications.html
@@ -28,6 +28,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>Rich Media Notifications</title>
   <!-- ## Setup -->
   <!--
     Depending on whether you're implementing custom media notifications for `amp-audio`,

--- a/src/30_Advanced/Star_Rating.html
+++ b/src/30_Advanced/Star_Rating.html
@@ -18,6 +18,7 @@
 <head>
   <meta charset="utf-8">
   <link rel="canonical" href="<%host%>/advanced/star_rating/">
+  <title>Star Rating</title>
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 

--- a/src/30_Advanced/Tab_Panels_with_amp-selector.html
+++ b/src/30_Advanced/Tab_Panels_with_amp-selector.html
@@ -13,6 +13,7 @@
 
 <head>
     <meta charset="utf-8">
+  <title>Tab Panels with amp-selector</title>
     <link rel="canonical" href="<%host%>/advanced/tab_panels_with_amp-selector/">
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/30_Advanced/Using_the_AMP_URL_API.html
+++ b/src/30_Advanced/Using_the_AMP_URL_API.html
@@ -8,6 +8,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>Using the AMP URL API</title>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <script async custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js"></script>
   <link rel="canonical" href="<%host%>/advanced/using_the_amp_url_api/">

--- a/src/30_Advanced/Using_the_Google_AMP_Cache.html
+++ b/src/30_Advanced/Using_the_Google_AMP_Cache.html
@@ -13,6 +13,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>Using the Google AMP Cache</title>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <script async custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js"></script>
   <link rel="canonical" href="<%host%>/advanced/using_the_google_amp_cache/">

--- a/src/30_Advanced/Video_Carousels_with_amp-carousel.html
+++ b/src/30_Advanced/Video_Carousels_with_amp-carousel.html
@@ -7,6 +7,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>Video Carousels with amp-carousel</title>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <!-- ## Setup -->
   <!--

--- a/src/30_Advanced/amp-user-notification_with_Server_Endpoint.html
+++ b/src/30_Advanced/amp-user-notification_with_Server_Endpoint.html
@@ -10,6 +10,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>amp-user-notification with Server Endpoint</title>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <!-- ## Setup -->
   <!-- Import `amp-user-notification` in the header. -->

--- a/src/40_Dynamic_AMP/How_to_embed_interactive_elements_on_AMP_pages%3F.html
+++ b/src/40_Dynamic_AMP/How_to_embed_interactive_elements_on_AMP_pages%3F.html
@@ -20,6 +20,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>How to create interactive AMP pages?</title>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <!-- ## Setup -->
   <!--

--- a/src/60_Samples_%26_Templates/Comment_Section.html
+++ b/src/60_Samples_%26_Templates/Comment_Section.html
@@ -11,6 +11,7 @@ This sample showcases how to build a comment section in AMP HTML using the [amp-
 <html ⚡>
 <head>
     <meta charset="utf-8">
+  <title>Comment Section</title>
     <script async src="https://cdn.ampproject.org/v0.js"></script>
     <!--
     Additionally used AMP components must be imported in the header.

--- a/src/60_Samples_%26_Templates/Hotel.html
+++ b/src/60_Samples_%26_Templates/Hotel.html
@@ -13,6 +13,7 @@
 <html ⚡>
 <head>
 <meta charset="utf-8">
+  <title>Hotel</title>
 <script async src="https://cdn.ampproject.org/v0.js"></script>
 <!-- ## Setup -->
 <!--

--- a/src/60_Samples_%26_Templates/Housing.html
+++ b/src/60_Samples_%26_Templates/Housing.html
@@ -12,6 +12,7 @@ This sample showcases how to build a housing page in AMP HTML. Explore how to us
 <html ⚡>
 <head>
     <meta charset="utf-8">
+  <title>Housing</title>
     <script async src="https://cdn.ampproject.org/v0.js"></script>
     <!--
     Additionally used AMP components must be imported in the header.

--- a/src/60_Samples_%26_Templates/Live_Blog.html
+++ b/src/60_Samples_%26_Templates/Live_Blog.html
@@ -13,6 +13,7 @@ This is a sample template for implementing live blogs in AMP.
 <html ⚡>
   <head>
     <meta charset="utf-8">
+  <title>Live Blog</title>
       <script async src="https://cdn.ampproject.org/v0.js"></script>
     <!-- ## Setup -->
     <!--

--- a/src/60_Samples_%26_Templates/News_Article.html
+++ b/src/60_Samples_%26_Templates/News_Article.html
@@ -10,6 +10,7 @@
   <html ⚡>
     <head>
       <meta charset="utf-8">
+  <title>News Article</title>
       <script async src="https://cdn.ampproject.org/v0.js"></script>
       <!-- ## Setup -->
       <!--

--- a/src/60_Samples_%26_Templates/Poll.html
+++ b/src/60_Samples_%26_Templates/Poll.html
@@ -12,6 +12,7 @@
 <html ⚡>
 <head>
 <meta charset="utf-8">
+  <title>Poll</title>
 <script async src="https://cdn.ampproject.org/v0.js"></script>
 <!-- ## Setup -->
 <!--

--- a/src/60_Samples_%26_Templates/Product_Browse_Page.html
+++ b/src/60_Samples_%26_Templates/Product_Browse_Page.html
@@ -11,6 +11,7 @@
   <html ⚡>
     <head>
       <meta charset="utf-8">
+  <title>Product Browse Page</title>
       <script async src="https://cdn.ampproject.org/v0.js"></script>
       <!--
         Additionally used AMP components must be imported in the header.

--- a/src/60_Samples_%26_Templates/Product_Page.html
+++ b/src/60_Samples_%26_Templates/Product_Page.html
@@ -13,6 +13,7 @@ This sample showcases how to build a product page in AMP HTML.
 <html ⚡>
 <head>
     <meta charset="utf-8">
+  <title>Product Page</title>
     <meta name="amp-experiment-token" content="HfmyLgNLmblRg3Alqy164Vywr">
     <script async src="https://cdn.ampproject.org/v0.js"></script>
 

--- a/src/amp-ads/10_Introduction/AMPHTML_ads_vs_non-AMP_ads.html
+++ b/src/amp-ads/10_Introduction/AMPHTML_ads_vs_non-AMP_ads.html
@@ -15,6 +15,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
+  <title>AMP Ads vs non-AMP Ads</title>
   <link rel="canonical" href="<%host%>/amp_ads/amp_ads_vs_non-amp_ads/">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/src/amp-ads/10_Introduction/_Hello_World.html
+++ b/src/amp-ads/10_Introduction/_Hello_World.html
@@ -24,6 +24,7 @@
 <head>
   <!-- The charset definition must be the first child of the `<head>` tag. -->
   <meta charset="utf-8">
+  <title> Hello World</title>
   <!-- AMPHTML ads require a custom version of the AMP runtime.-->
   <script async src="https://cdn.ampproject.org/amp4ads-v0.js"></script>
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">

--- a/src/amp-ads/20_Basic_Ads/Banner_Ad.html
+++ b/src/amp-ads/20_Basic_Ads/Banner_Ad.html
@@ -18,6 +18,7 @@
 <head>
 
   <meta charset="utf-8">
+  <title>Banner Ad</title>
   <script async src="https://cdn.ampproject.org/amp4ads-v0.js"></script>
   <!-- ## Setup -->
   <!--

--- a/src/amp-ads/20_Basic_Ads/Carousel_Ad.html
+++ b/src/amp-ads/20_Basic_Ads/Carousel_Ad.html
@@ -20,6 +20,7 @@
 <head>
 
   <meta charset="utf-8">
+  <title>Carousel Ad</title>
   <script async src="https://cdn.ampproject.org/amp4ads-v0.js"></script>
   <!-- ## Setup -->
   <!--

--- a/src/amp-ads/30_Advanced_Ads/Video_Ad.html
+++ b/src/amp-ads/30_Advanced_Ads/Video_Ad.html
@@ -21,6 +21,7 @@
 <html ⚡4ads>
 <head>
   <meta charset="utf-8">
+  <title>Video Ad</title>
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <script async src="https://cdn.ampproject.org/amp4ads-v0.js"></script>
   <!-- ## Setup -->

--- a/src/amp-ads/40_Experimental_Ads/Carousel_Lightbox_Ad.html
+++ b/src/amp-ads/40_Experimental_Ads/Carousel_Lightbox_Ad.html
@@ -12,6 +12,7 @@
 <html amp4ads lang="en">
   <head>
     <meta charset="utf-8">
+  <title>Carousel Lightbox Ad</title>
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <script async custom-element="amp-carousel" src="https://amp-ads.firebaseapp.com/dist/v0/amp-carousel-0.1.max.js"></script>
     <script async custom-element="amp-lightbox" src="https://amp-ads.firebaseapp.com/dist/v0/amp-lightbox-0.1.max.js"></script>

--- a/src/amp-ads/40_Experimental_Ads/Scrollbound_Lightbox_Ad.html
+++ b/src/amp-ads/40_Experimental_Ads/Scrollbound_Lightbox_Ad.html
@@ -13,6 +13,7 @@
 <html amp4ads lang="en">
   <head>
     <meta charset="utf-8">
+  <title>Scrollbound Lightbox Ad</title>
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <script async src="https://amp-ads.firebaseapp.com/dist/amp-inabox.js"></script>
     <script async custom-element="amp-animation" src="https://amp-ads.firebaseapp.com/dist/v0/amp-animation-0.1.max.js"></script>

--- a/src/amp-ads/40_Experimental_Ads/Scrollbound_Slides_360_Ad.html
+++ b/src/amp-ads/40_Experimental_Ads/Scrollbound_Slides_360_Ad.html
@@ -14,6 +14,7 @@
 
 <head>
   <meta charset="utf-8">
+  <title>Scrollbound Slides 360 Ad</title>
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <script async src="https://amp-ads.firebaseapp.com/dist/amp-inabox.js"></script>
   <script async custom-element="amp-animation" src="https://amp-ads.firebaseapp.com/dist/v0/amp-animation-0.1.max.js"></script>

--- a/src/amp-ads/40_Experimental_Ads/Scrollbound_Video_Ad.html
+++ b/src/amp-ads/40_Experimental_Ads/Scrollbound_Video_Ad.html
@@ -14,6 +14,7 @@
 
 <head>
   <meta charset="utf-8">
+  <title>Scrollbound Video Ad</title>
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <script async src="https://amp-ads.firebaseapp.com/dist/amp-inabox.js"></script>
   <script async custom-element="amp-animation" src="https://amp-ads.firebaseapp.com/dist/v0/amp-animation-0.1.max.js"></script>

--- a/src/amp-ads/40_Experimental_Ads/Slides_With_Lightbox_Ad.html
+++ b/src/amp-ads/40_Experimental_Ads/Slides_With_Lightbox_Ad.html
@@ -12,6 +12,7 @@
 <html amp4ads lang="en">
   <head>
     <meta charset="utf-8">
+  <title>Slides With Lightbox Ad</title>
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <script async custom-element="amp-bind" src="https://amp-ads.firebaseapp.com/dist/v0/amp-bind-0.1.max.js"></script>
     <script async custom-element="amp-lightbox" src="https://amp-ads.firebaseapp.com/dist/v0/amp-lightbox-0.1.max.js"></script>

--- a/src/amp-ads/40_Experimental_Ads/Stack_With_Bind_Ad.html
+++ b/src/amp-ads/40_Experimental_Ads/Stack_With_Bind_Ad.html
@@ -11,6 +11,7 @@
 <html amp4ads lang="en">
   <head>
     <meta charset="utf-8">
+  <title>Stack With Bind Ad</title>
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <script async custom-element="amp-bind" src="https://amp-ads.firebaseapp.com/dist/v0/amp-bind-0.1.max.js"></script>
     <script async custom-element="amp-selector" src="https://amp-ads.firebaseapp.com/dist/v0/amp-selector-0.1.max.js"></script>

--- a/tasks/create-example.js
+++ b/tasks/create-example.js
@@ -16,6 +16,7 @@
 
 "use strict";
 
+const path = require('path');
 const through = require('through2');
 const gutil = require('gulp-util');
 const PluginError = gutil.PluginError;
@@ -26,7 +27,7 @@ const ExampleFile = require('../lib/ExampleFile');
 /**
  * Create an empty example.
  */
-module.exports = function(config) {
+module.exports = function(paths, config) {
   let templateName;
   let templates;
 
@@ -54,8 +55,9 @@ module.exports = function(config) {
             'Streams not supported!'));
     } else if (file.isBuffer()) {
       const stream = this;
-      const exampleFile = ExampleFile.fromPath(file.path);
-      gutil.log('Creating example ' + file.relative);
+      const exampleFilePath = path.join(paths.src, file.path);
+      const exampleFile = ExampleFile.fromPath(exampleFilePath);
+      gutil.log('Created ' + exampleFilePath);
       const args = {
         config: config,
         title: exampleFile.title(),

--- a/templates/new-example.html
+++ b/templates/new-example.html
@@ -8,9 +8,10 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
-  <link rel="canonical" href="<%host%>{{fileName}}">
+  <link rel="canonical" href="{{fileName}}">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <title>{{title}}</title>
   <!-- ## Setup -->
   <!--
   TODO: explain which components need to be imported. No need to explain the AMP boilerplate.


### PR DESCRIPTION
A title get's added to the example pages, but the source file don't
contain a title.

This also fixes the bug where the canonical link wasn't correctly set
for new samples.