### PR TITLE
Display experiments array

### DIFF
--- a/templates/experiment.html
+++ b/templates/experiment.html
@@ -1,6 +1,6 @@
 <div class="abe-experiment-warning ampstart-card p1">
   <h4 class="mb1">Experimental Mode</h4>
-  <p>This example uses the following experimental feature{{#metadata.experiments.1}}s{{/metadata.experiments.1}}: <code class="amp-experiment-list">[{{metadata.experiments}}]</code>. Enable the experiment via the button below. Some components require the AMP Dev Channel to be enabled as well. <a href="https://www.ampproject.org/docs/reference/experimental.html">Learn more here</a>.</p>
+  <p>This example uses the following experimental feature{{#metadata.experiments.1}}s{{/metadata.experiments.1}}: <code class="amp-experiment-list">[{{metadata.experiments}}]</code>. Enable the experiment{{#metadata.experiments.1}}s{{/metadata.experiments.1}} via the button below. Some components require the AMP Dev Channel to be enabled as well. <a href="https://www.ampproject.org/docs/reference/experimental.html">Learn more here</a>.</p>
 
   <div class="abe-experiment-warning-buttons flex flex-wrap">
     <button id="experiment-toggle" class="ampstart-btn ampstart-btn-secondary caps mr1 mt1" disabled>Enable Experiment{{#metadata.experiments.1}}s{{/metadata.experiments.1}}</button>

--- a/templates/experiment.html
+++ b/templates/experiment.html
@@ -1,6 +1,6 @@
 <div class="abe-experiment-warning ampstart-card p1">
   <h4 class="mb1">Experimental Mode</h4>
-  <p>This example uses the following experimental feature{{#metadata.experiments.1}}s{{/metadata.experiments.1}}: <code class="amp-experiment-list">[{{#metadata.experiments}}<span>{{.}}</span>{{/metadata.experiments}}]</code>. Enable the experiment via the button below. Some components require the AMP Dev Channel to be enabled as well. <a href="https://www.ampproject.org/docs/reference/experimental.html">Learn more here</a>.</p>
+  <p>This example uses the following experimental feature{{#metadata.experiments.1}}s{{/metadata.experiments.1}}: <code class="amp-experiment-list">[{{metadata.experiments}}]</code>. Enable the experiment via the button below. Some components require the AMP Dev Channel to be enabled as well. <a href="https://www.ampproject.org/docs/reference/experimental.html">Learn more here</a>.</p>
 
   <div class="abe-experiment-warning-buttons flex flex-wrap">
     <button id="experiment-toggle" class="ampstart-btn ampstart-btn-secondary caps mr1 mt1" disabled>Enable Experiment{{#metadata.experiments.1}}s{{/metadata.experiments.1}}</button>


### PR DESCRIPTION
we don't separate experiments name by comma, it looks like `[amp-animationamp-google-vrview-imageamp-lightbox-a4a-proto]` now
https://ampbyexample.com/amp-ads/experimental_ads/scrollbound_slides_360_ad/
