### PR TITLE
Add temp fix to serve lightbox ad

### DIFF
--- a/src/amp-ads/40_Experimental_Ads/Lightbox_Ad.html
+++ b/src/amp-ads/40_Experimental_Ads/Lightbox_Ad.html
@@ -231,6 +231,7 @@
               layout="responsive"
               alt="Ergonomic Leather Seats"></amp-img>
         </div>
+      </div>
     </amp-ad-banner>
     <!-- ## Lightboxes -->
     <!--

--- a/src/amp-ads/40_Experimental_Ads/Lightbox_Ad.html
+++ b/src/amp-ads/40_Experimental_Ads/Lightbox_Ad.html
@@ -1,0 +1,278 @@
+<!---{
+ "preview": "a4a",
+ "skipValidation": true,
+ "hidePreview": true,
+ "experiments": ["amp-lightbox-a4a-proto"],
+ "width": 350,
+ "height": 240,
+ "layout": "responsive",
+ "scrollToReveal": true,
+ "adExp": true
+}--->
+<!-- -->
+<!doctype html>
+<html amp4ads lang="en">
+  <head>
+    <meta charset="utf-8">
+  <title>Scrollbound Lightbox Ad</title>
+    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+    <script async src="https://amp-ads.firebaseapp.com/dist/amp-inabox.js"></script>
+    <script async custom-element="amp-lightbox" src="https://amp-ads.firebaseapp.com/dist/v0/amp-lightbox-0.1.max.js"></script>
+    <style amp4ads-boilerplate>body{visibility:hidden}</style>
+    <!-- ## Summary-->
+    <!--
+    Sample AMPHTML ad using [amp-lightbox](https://www.ampproject.org/docs/reference/components/amp-lightbox).    -->
+    <!-- ## Styling -->
+    <!--
+    This is an advanced example that requires some styling to make it look and function properly.
+    The styling designed here is responsive and will work with various ad sizes.
+    -->
+    <style amp-custom>
+      /* Main element that contains the creative. */
+      .root-container {
+        background: #000;
+        color: #fff;
+        font-family: 'Roboto', sans-serif;
+        font-size: 12px;
+        overflow: hidden;
+        width: 340px;
+        height: 240px;
+        position: relative;
+        margin: 0 auto;
+        display: block;
+      }
+      .logo-img {
+        display: block;
+      }
+      .stretch {
+        flex: 1;
+      }
+      .button {
+        text-transform: uppercase;
+        padding: 8px;
+        color: #fff;
+        display: inline-block;
+        background-color: #2979ff;
+        text-decoration: none;
+      }
+      .button:active {
+        background-color: #92bbff;
+      }
+      /* Basic cards styling */
+      .cards-container {
+        position: absolute;
+        z-index: 1;
+        left: 0;
+        right: 0;
+      }
+      .card {
+        width: 100%;
+        overflow: hidden;
+        position: relative;
+      }
+      /* Position expand button absolutely on top of the card */
+      .expand-button {
+        padding: 0;
+        width: 44px;
+        height: 44px;
+        line-height: 44px;
+        text-align: center;
+        position: absolute;
+        z-index: 1;
+        left: 40%;
+        top: 40%;
+        font-size: 24px;
+        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.8);
+      }
+      /* Change position of the expand button for the middle card */
+      .card-gauges .expand-button {
+        left: 90px;
+        top: 50px;
+      }
+      /* Lightbox styling */
+      amp-lightbox {
+        font-family: 'Roboto', sans-serif;
+        font-size: 12px;
+        background: rgba(0, 0, 0, 0.8);
+      }
+      .lightbox {
+        height: 100%;
+        margin: 0 auto 0;
+        max-width: 600px;
+        background: #fff;
+        color: #888;
+        overflow: hidden;
+        position: relative;
+        display: flex;
+        flex-direction: column;
+        box-shadow: 0 5px 20px rgba(0, 0, 0, 0.3);
+      }
+      .lightbox-main {
+        flex: 1;
+        display: flex;
+        max-width: 340px;
+        flex-direction: column;
+        align-items: center;
+        text-align: center;
+        padding: 30px 20px;
+        line-height: 20px;
+        align-self: center;
+      }
+      .lightbox-main p {
+        margin: 5px 0;
+      }
+      .lightbox-main h3 {
+        text-transform: uppercase;
+        margin: 10px auto 0;
+        font-weight: normal;
+        letter-spacing: 2px;
+        font-size: 14px;
+        color: #000;
+        align-self: center;
+        max-width: 320px;
+      }
+      /* Creates decorative underline for h3 headers */
+      .lightbox-main h3:after {
+        display: block;
+        content: " ";
+        background-color: #2979ff;
+        width: 20px;
+        height: 3px;
+        margin: 12px auto 10px;
+      }
+      .lightbox-close-container {
+        text-align: center;
+        border-top: 1px solid #eee;
+        padding: 18px 0;
+      }
+      .lightbox-header {
+        background: #000;
+        text-align: center;
+        padding: 10px 0;
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .lightbox-header h1  {
+        display: inline;
+        color: #fff;
+        text-transform: uppercase;
+        font-weight: normal;
+        font-size: 14px;
+        border-left: 1px solid #fff;
+        margin: 0 0 0 12px;
+        padding-left: 12px;
+      }
+      .lightbox-hero {
+        position: relative;
+        overflow: hidden;
+      }
+      .learn-more a {
+        padding: 8px;
+        text-transform: uppercase;
+        display: inline-block;
+        color: #2979ff;
+        text-decoration: none;
+        font-weight: bold;
+      }
+      .learn-more a:active {
+        background-color: #f0f0f0;
+      }
+      /* Responsive styles so that the lightbox does not over-stretch */
+      @media (max-height: 500px) {
+        .lightbox {
+          max-width: 400px;
+        }
+        .lightbox-hero {
+          max-height: 160px;
+        }
+        .lightbox-hero-img {
+          margin-top: -30px;
+        }
+      }
+      @media (max-height: 360px) {
+        .lightbox-hero-img {
+          display: none;
+        }
+        .lightbox-header {
+          position: static;
+        }
+      }
+    </style>
+  </head>
+  <body>
+
+    <!-- ## Banner markup -->
+    <!--
+    `amp-ad-banner` is a dummy AMP element that is used by the AMP runtime to determine the position of the ad when a lightbox is opened.
+
+    Please note that `amp-ad-banner` is still in experimental stages and is
+    likely to change in the future. See [this Github issue for tracking.](https://github.com/ampproject/amphtml/issues/8334)
+    -->
+    <amp-ad-banner class="root-container" layout="container">
+      <!-- ## Cards -->
+      <!--
+      AMP has a system in place for [events and actions](https://github.com/ampproject/amphtml/blob/master/spec/amp-actions-and-events.md). It uses a domain-specific language to describe how actions are triggered. In this example, we set the `on` attribute so the lightbox will activate when a card button is tapped.
+
+      Each button opens the lightbox related to the card that triggers it.
+      -->
+      <div class="cards-container" id="cardsContainer">
+        <div class="card card-seats">
+          <div class="button expand-button"
+              role="button"
+              on="tap:lightbox-seats.activate">+</div>
+          <amp-img src="<%host%>/img/car-seats.jpg"
+              width="340"
+              height="240"
+              layout="responsive"
+              alt="Ergonomic Leather Seats"></amp-img>
+        </div>
+    </amp-ad-banner>
+    <!-- ## Lightboxes -->
+    <!--
+    The amp-lightbox component defines the child elements that will be displayed in a full-viewport overlay.
+    We set a different id for each lightbox so they can be opened and closed by actions on other elements.
+    Its content is normal AMP HTML.
+    -->
+    <amp-lightbox id="lightbox-seats" layout="nodisplay">
+      <div class="lightbox">
+        <div class="lightbox-hero">
+          <amp-img src="<%host%>/img/car-seats.jpg"
+              width="608"
+              height="342"
+              layout="responsive"
+              alt="Ergonomic Leather Seats"
+              class="lightbox-hero-img"></amp-img>
+          <div class="lightbox-header">
+            <amp-img src="<%host%>/img/car-logo.png"
+                width="72"
+                height="32"
+                layout="fixed"
+                alt="Howdy"
+                class="logo-img"></amp-img>
+            <h1>The all-new WX-S R5</h1>
+          </div>
+        </div>
+        <div class="lightbox-main">
+          <h3>Ergonomic Leather Seats</h3>
+          <p>
+            Available in Comfort Suede and leather. High-contrast stitching colors available.
+          </p>
+          <p class="learn-more">
+            <a href="https://ampbyexample.com/" target="_blank">Learn more</a>
+          </p>
+        </div>
+        <div class="lightbox-close-container">
+          <div class="button lightbox-close-button" role="button"
+              on="tap:lightbox-seats.close">
+            Close
+          </div>
+        </div>
+      </div>
+    </amp-lightbox>
+  </body>
+</html>

--- a/src/amp-ads/40_Experimental_Ads/Scrollbound_Slides_360_Ad.html
+++ b/src/amp-ads/40_Experimental_Ads/Scrollbound_Slides_360_Ad.html
@@ -1,0 +1,255 @@
+<!---{
+ "preview": "a4a",
+ "skipValidation": true,
+ "hidePreview": true,
+ "experiments": ["amp-animation", "amp-google-vrview-image", "amp-lightbox-a4a-proto"],
+ "width": 350,
+ "height": 250,
+ "layout": "responsive",
+ "scrollToReveal": true,
+ "adExp": true
+}--->
+<!-- -->
+<!doctype html>
+<html ⚡4ads>
+
+<head>
+  <meta charset="utf-8">
+  <title>Scrollbound Slides 360 Ad</title>
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <script async src="https://amp-ads.firebaseapp.com/dist/amp-inabox.js"></script>
+  <script async custom-element="amp-animation" src="https://amp-ads.firebaseapp.com/dist/v0/amp-animation-0.1.max.js"></script>
+  <script async custom-element="amp-lightbox" src="https://amp-ads.firebaseapp.com/dist/v0/amp-lightbox-0.1.max.js"></script>
+<script async custom-element="amp-google-vrview-image" src="https://amp-ads.firebaseapp.com/dist/v0/amp-google-vrview-image-0.1.max.js"></script>
+  <style amp4ads-boilerplate>
+    body {
+      visibility: hidden
+    }
+  </style>
+
+  <!-- ## Summary-->
+  <!--
+    Sample AMPHTML ad using [amp-animation](https://www.ampproject.org/docs/reference/components/amp-animation),
+    [amp-lightbox](https://www.ampproject.org/docs/reference/components/amp-lightbox),
+    [amp-google-vrview-image](https://www.ampproject.org/docs/reference/components/amp-google-vrview-image),
+    and [amp-img](https://www.ampproject.org/docs/reference/components/amp-img)
+    to create an ad that changes slides based on scrolling and displays a 360 image in a lightbox.
+
+    <img src="https://cloud.githubusercontent.com/assets/2099009/26142066/be812a52-3a93-11e7-8bf7-937a49109128.gif" width="303" alt="Demo of this example"></img>
+  -->
+
+  <!-- ## Styling -->
+  <!--
+  This is an advanced example that requires some styling to make it
+  look and function properly. The styling designed here is responsive and will work with various ad sizes.
+  -->
+  <style amp-custom>
+
+    /*
+     * Top level container: It fills the parent viewport
+     * that hosts the ad.
+     */
+    .ad-container {
+      font-family: "Roboto", sans-serif;
+      width: 100vw;
+      height: 100vh;
+      color: #FFFFFF;
+    }
+
+    /* Content Layer */
+    .content-container {
+      z-index: 1;
+    }
+
+    /* Content Layer: Title and logo */
+    .title {
+      position: absolute;
+      top: 40%;
+      left: 0;
+      padding: 15px;
+      transform: translate(0, -40%);
+      background: rgba(0,0,0,0.8);
+      font-weight: bold;
+    }
+
+    .vr360-button {
+      position: absolute;
+      top: 40%;
+      transform: translate(0, -40%);
+      height: auto;
+      right: 0px;
+      display: flex;
+      flex-direction: row;
+    }
+
+    .vr360-button>* {
+      flex: 1;
+    }
+
+    .next {
+      padding: 2px;
+      margin-left: 2px;
+      background-repeat: no-repeat;
+      background-position: center center;
+      background-image: url('<%host%>/img/arrow.svg');
+      transform: rotate(180deg);
+      background-size: contain;
+    }
+
+    /* Content Layer: Footer and learn more button */
+    .footer {
+      position: absolute;
+      bottom: 0;
+      width: 100%;
+      padding: 5px 10px;
+      background-color: rgba(0, 0, 0, 0.8);
+      box-sizing: border-box;
+      font-size: 10px;
+      display: flex;
+      flex-direction: row;
+    }
+
+    .footer>* {
+      flex: 1;
+      align-self: center;
+    }
+
+    .footer>.center {
+      flex: 2;
+    }
+
+    .logo {
+      margin-right: 10px;
+    }
+
+    .button {
+      flex: 0;
+      font-size: 10px;
+      background-color: #2979ff;
+      padding: 5px 15px;
+      white-space: nowrap;
+      letter-spacing: 0.5px;
+      color: #fafafa;
+      text-decoration: none;
+      cursor: pointer
+    }
+
+    /* Generic CSS class to fill a parent */
+    .fill {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+    }
+
+    /* Lightbox styles */
+    .lightbox-back-button {
+      position: absolute;
+      z-index: 1;
+      cursor: pointer;
+      width: 60px;
+      height: 60px;
+      background-repeat: no-repeat;
+      background-position: center center;
+      background-image: url('<%host%>/img/arrow.svg');
+    }
+
+    #lightbox-vr {
+      background: #f9f7f7;
+    }
+
+    .ad-container img {
+      object-fit: cover;
+    }
+
+  </style>
+</head>
+
+<body>
+  <!-- ## Scrollbound Slide Change Animation -->
+  <!--
+    The animation is implemented using [amp-animation](https://www.ampproject.org/docs/reference/components/amp-animation)
+    which is an experimental AMP component that uses [Web Animations API](https://www.w3.org/TR/web-animations/)
+    to support both __time__ and __scroll__ based animations.
+  -->
+  <amp-animation layout="nodisplay" trigger="visibility">
+    <script type="application/json">
+      {
+      "ticker": "scroll",
+      "fill": "both",
+      "animations": [
+        {
+          "target": "slides",
+          "keyframes": [
+            { "transform": "translateY(0)" },
+            { "transform": "translateY(0)", "offset": 0.5 },
+            { "transform": "translateY(-100vh)", "offset": 0.5 },
+            { "transform": "translateY(-100vh)", "offset": 1 }
+          ]
+        }
+      ]
+    }
+    </script>
+  </amp-animation>
+  <!--
+    **scroll vs. time ticker**: Setting `"ticker": "scroll"` tells
+    `amp-animation` to advance the animation timeline based on scrolling rather than time.
+
+    **Sliding images**:
+    We have two images of 100vh height for this ad, we switch between them by moving
+    the parent container -100vh at the middle keyframe of the scrollbound animation as defined above.
+  -->
+
+  <!-- ## Lightbox with 360 image -->
+  <!--
+  The amp-lightbox component defines the child elements that will be displayed in a full-viewport overlay.
+  We set a different id for each lightbox so they can be opened and closed by actions on other elements.
+
+  Inside the lightbox we create an `amp-google-vrview-image` component which can display VR and 360
+  images and videos.
+  -->
+  <amp-lightbox id="lightbox-vr" layout="nodisplay">
+    <div class="lightbox-back-button" role="button" tabindex="0"
+         on="tap:lightbox-vr.close">
+    </div>
+    <amp-google-vrview-image yaw="90" src="<%host%>/img/car-vr-360.jpg"
+      layout="fill">
+    </amp-google-vrview-image>
+  </amp-lightbox>
+
+  <!-- ## Ad Container -->
+  <!--
+  Top level container: It fills the parent viewport that hosts the ad.
+
+  `amp-ad-banner` is a dummy AMP element that is used by the AMP runtime to determine the position of the ad when a lightbox is opened.
+  -->
+  <amp-ad-banner class="ad-container" layout="container">
+    <!-- ## Content Layer -->
+    <!--
+    Create the content layer that hosts the slide images and information about the ad.
+    -->
+    <div class="content-container fill">
+      <div id="slides">
+        <amp-img height="100vh" layout="fixed-height" src="<%host%>/img/car-side-bg.jpg"></amp-img>
+        <amp-img height="100vh" layout="fixed-height" src="<%host%>/img/car-tunnel.jpg"></amp-img>
+      </div>
+      <div class="title">
+        <div>THE ALL NEW</div>
+        <div>HOWDY WS-X LUX</div>
+      </div>
+      <div class="vr360-button" on="tap:lightbox-vr.activate" role="button" tabindex="0">
+        <div class="button">EXPLORE 360</div>
+        <div class="button next"></div>
+      </div>
+      <div class="footer">
+        <div><amp-img class="logo" layout="fixed" width="72" height="32" src="<%host%>/img/car-logo.png"></amp-img></div>
+        <div class="center"><span>36 months lease, $189/month, $2999 due at signing</span></div>
+        <div><a href="https://ampproject.org" target="blank_" class="button">LEARN MORE</a></div>
+      </div>
+    </div>
+  </amp-ad-banner>
+
+</body>
+
+</html>

--- a/templates/preview-a4a.html
+++ b/templates/preview-a4a.html
@@ -5,8 +5,15 @@
     <meta name="viewport" content="width=device-width,minimum-scale=1">
     {{> head.html}}
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
-    <script async src="https://cdn.ampproject.org/v0.js"></script>
-    <script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script>
+    {{#metadata.adExp}}
+      <script async src="https://amp-ads.firebaseapp.com/dist/amp.js"></script>
+      <script async custom-element="amp-ad" src="https://amp-ads.firebaseapp.com/dist/v0/amp-ad-0.1.max.js"></script>
+      <script async custom-element="amp-ad-fake" src="https://amp-ads.firebaseapp.com/dist/v0/amp-ad-network-fake-impl-0.1.max.js"></script>
+    {{/metadata.adExp}}
+    {{^metadata.adExp}}
+      <script async src="https://cdn.ampproject.org/v0.js"></script>
+      <script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script>
+    {{/metadata.adExp}}
     <style amp-custom>
       {{> css/code.css}}
       {{> css/ampstart.css}}
@@ -144,16 +151,30 @@
                 layout="{{layout}}"
                 data-slot="{{metadata.adSlot}}"></amp-ad>
         {{/metadata.adSlot}}
-        {{^metadata.adSlot}}
-        <amp-ad layout="{{layout}}"
-          width="{{width}}"
-          height="{{height}}"
-          type="fake"
-          id="i-amphtml-demo-fake"
-          a4a-conversion="true"
-          disable3pfallback="false"
-          src="{{a4aEmbedUrl}}"></amp-ad>
-        {{/metadata.adSlot}}
+        {{#metadata.adExp}}
+        <amp-ad width="{{width}}"
+                height="{{height}}"
+                type="fake"
+                data-use-a4a="true"
+                force3p="false"
+                fakesig="true"
+                src="{{a4aEmbedUrl}}"
+                disable3pfallback="false">
+        <div placeholder="" class="amp-hidden"></div>
+        </amp-ad>
+        {{/metadata.adExp}}
+        {{^metadata.adExp}}
+          {{^metadata.adSlot}}
+          <amp-ad layout="{{layout}}"
+            width="{{width}}"
+            height="{{height}}"
+            type="fake"
+            id="i-amphtml-demo-fake"
+            a4a-conversion="true"
+            disable3pfallback="false"
+            src="{{a4aEmbedUrl}}"></amp-ad>
+          {{/metadata.adSlot}}
+        {{/metadata.adExp}}
       </div>
       <p class="pb1">
       Tempor neque nisl in fermentum, nulla duis duis feugiat. Leo aenean sit, laudantium fermentum aliquet sagittis nec ac ac, donec ac tincidunt sollicitudin lacus neque. Morbi tellus autem pede bibendum, natoque maecenas justo ac, nec aliquam taciti, pellentesque nam iaculis eros nec at. Proin in orci. Et eu nec montes rutrum nullam, nunc pharetra gravida elit, consectetuer consequatur, eros dignissim, justo vel suspendisse. Ipsum quis metus ultricies nullam nullam. Quis at luctus sit pede etiam, tellus vitae, maecenas mauris nibh lacinia est augue. Aenean nec cursus aptent sit odio tempor, felis duis nulla vel varius mauris, risus duis ac.</p>


### PR DESCRIPTION
This is a temporary fix.
Lightbox doesn't work because of amp cors check
The easiest fix would be on the runtime side, to disable the check for fake ad type. 
Another fix would be to add middleware to ampbyexample server, but I figure it's a little bit risky to make the change now.
So I introduced this temporary fix, that should be able to remove after we make the real fix on to AMP runtime. 

@sebastianbenz PTAL and had this change in for the deployment. Thanks! 