### PR TITLE
Add basic example for <amp-lightbox-gallery>

### DIFF
--- a/src/20_Components/amp-lightbox-gallery.html
+++ b/src/20_Components/amp-lightbox-gallery.html
@@ -17,8 +17,9 @@ The amp-lightbox-gallery component provides a "lightbox” experience for AMP co
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <title>amp-lightbox-gallery</title>
   <!-- ## Setup -->
-  <!-- Import the amp-lightbox-gallery component in the header. Only import amp-carousel if you are using a carousel. -->
+  <!-- Import the amp-lightbox-gallery component in the header.  -->
   <script async custom-element="amp-lightbox-gallery" src="https://cdn.ampproject.org/v0/amp-lightbox-gallery-0.1.js"></script>
+  <!-- Optionally import the amp-carousel component in the header if you are using lightbox with carousel.  -->
   <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <link rel="canonical" href="<%host%>/components/amp-lightbox-gallery/">
@@ -28,15 +29,17 @@ The amp-lightbox-gallery component provides a "lightbox” experience for AMP co
 
   <!-- ## Basic Usage -->
   <!--
-  This is a basic example. You have one or more `<amp-img>` elements on the page. Just add the "lightbox" attribute to each image that you wish to see in a lightbox.
+  This is a basic example that demonstrates lightboxed `<amp-img>`s. You have one or more `<amp-img>` elements on the page. Just add the "lightbox" attribute to each image that you wish to view in a lightbox.
   -->
   <div>
-    <amp-img lightbox src="/img/image1.jpg" width="400" height="300" layout="responsive" role="button"></amp-img>
+    <amp-img lightbox src="/img/image1.jpg" width="400" height="300" layout="responsive"></amp-img>
+    <amp-img lightbox src="/img/image2.jpg" width="400" height="300" layout="responsive"></amp-img>
+    <amp-img lightbox src="/img/image1.jpg" width="400" height="300" layout="responsive"></amp-img>
     <amp-img lightbox src="/img/image2.jpg" width="400" height="300" layout="responsive"></amp-img>
   </div>
   <!-- ## Usage with Carousel-->
   <!--
-  You can also use `<amp-lightbox-gallery>` with `<amp-carousel>`. Just simply include a `<amp-carousel>` with `<amp-img>`s, and add the "lightbox" attribute to the `<amp-carousel>`.
+  You can also use `<amp-lightbox-gallery>` with `<amp-carousel>` to view the contents of the carousel in a lightbox. Just simply include a `<amp-carousel>` with `<amp-img>`s, and add the "lightbox" attribute to the `<amp-carousel>`. The lightbox images will be sync-ed with the carousel slides.
   -->
   <div>
     <amp-carousel lightbox width="400" height="300" layout="responsive" type="slides">

--- a/src/20_Components/amp-lightbox-gallery.html
+++ b/src/20_Components/amp-lightbox-gallery.html
@@ -1,0 +1,50 @@
+<!---{
+    "experiments": ["amp-lightbox-gallery"],
+    "preview": "default"
+}--->
+<!--
+  ## Introduction
+
+The amp-lightbox-gallery component provides a "lightbox” experience for AMP components (e.g., amp-img, amp-carousel). When the user interacts with the AMP element, a UI component expands to fill the viewport until it is closed by the user. Currently, only images are supported.
+-->
+<!-- -->
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="/components/amp-lightbox-gallery/">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <title>amp-lightbox-gallery</title>
+  <!-- ## Setup -->
+  <!-- Import the amp-lightbox-gallery component in the header. Only import amp-carousel if you are using a carousel. -->
+  <script async custom-element="amp-lightbox-gallery" src="https://cdn.ampproject.org/v0/amp-lightbox-gallery-0.1.js"></script>
+  <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link rel="canonical" href="<%host%>/components/amp-lightbox-gallery/">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+</head>
+<body>
+
+  <!-- ## Basic Usage -->
+  <!--
+  This is a basic example. You have one or more `<amp-img>` elements on the page. Just add the "lightbox" attribute to each image that you wish to see in a lightbox.
+  -->
+  <div>
+    <amp-img lightbox src="/img/image1.jpg" width="400" height="300" layout="responsive" role="button"></amp-img>
+    <amp-img lightbox src="/img/image2.jpg" width="400" height="300" layout="responsive"></amp-img>
+  </div>
+  <!-- ## Usage with Carousel-->
+  <!--
+  You can also use `<amp-lightbox-gallery>` with `<amp-carousel>`. Just simply include a `<amp-carousel>` with `<amp-img>`s, and add the "lightbox" attribute to the `<amp-carousel>`.
+  -->
+  <div>
+    <amp-carousel lightbox width="400" height="300" layout="responsive" type="slides">
+      <amp-img src="/img/image1.jpg" width="400" height="300" layout="responsive"></amp-img>
+      <amp-img src="/img/image2.jpg" width="400" height="300" layout="responsive"></amp-img>
+      <amp-img src="/img/image3.jpg" width="400" height="300" layout="responsive"></amp-img>
+    </amp-carousel>
+  </div>
+
+</body>
+</html>


### PR DESCRIPTION
This is a basic usage example for `<amp-lightbox-gallery>`, which is still under experimental mode. 