### PR TITLE
Remove mention of origin trial from <amp-social-share> example

### DIFF
--- a/src/20_Components/amp-social-share.html
+++ b/src/20_Components/amp-social-share.html
@@ -19,11 +19,6 @@
     Ensure you've configured your canonical URL.
   -->
   <link rel="canonical" href="<%host%>/components/amp-social-share/">
-  <!--
-    Origin trial tokens for `ampbyexample.com` and `*.cdn.ampproject.org`. (Needed for `type=system`; [see below](#native-share-dialog-chrome-on-android-).)
-  -->
-  <meta http-equiv="origin-trial" data-feature="Web Share" data-expires="2017-04-04" content="Ajcrk411RcpUCQ3ovgC8le4e7Te/1kARZsW5Hd/OCnW6vIHTs5Kcq1PaABs7SzcrtfvT0TIlFh9Vdb5xWi9LiQsAAABSeyJvcmlnaW4iOiJodHRwczovL2FtcGJ5ZXhhbXBsZS5jb206NDQzIiwiZmVhdHVyZSI6IldlYlNoYXJlIiwiZXhwaXJ5IjoxNDkxMzM3MDEwfQ==">
-  <meta http-equiv="origin-trial" data-feature="Web Share" data-expires="04/11/17" content="ArP55PINkEOG8GxebgOUGlUeleT5iZV2J1a5OVsIX4kq+89ZHBVKzoXikg0AiPOVQbJijM3fE+myhu62DEeCRwcAAABneyJvcmlnaW4iOiJodHRwczovL2Nkbi5hbXBwcm9qZWN0Lm9yZzo0NDMiLCJmZWF0dXJlIjoiV2ViU2hhcmUiLCJleHBpcnkiOjE0OTE5Mzc4NDEsImlzU3ViZG9tYWluIjp0cnVlfQ==">
 
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
@@ -98,20 +93,15 @@
 
   <!-- #### Native Share Dialog (Chrome on Android) -->
   <!--
-  If a couple of conditions are satisfied, the `system` type will display a native share
-  UI. (That is, exactly the same UI that's available to native applications, reflecting
-  the user's sharing preferences, the applications they have installed, and so on.)
 
-  The conditions are:
+  The `system` type will display a native share UI if the user is viewing the
+  AMP document using Chrome on Android. (The only supported browser as of
+  February 2018.)
 
-    * The user must be viewing the AMP using Chrome on Android. (The only supported browser as of February 2017.)
-    * An appropriate token (origin-specific) must be embedded on the site to activate the feature. ([Apply for a token](https://goo.gl/GR5YLI); [more information about the process](https://developers.google.com/web/updates/2016/10/navigator-share).)
+  Here's what it looks like in Chrome on Android:
 
-  For this example, we've embedded the tokens via `<meta>` elements [in the document `<head>`](#setup).
-
-  Here's what it looks like if conditions are right:
-
-  <amp-img class="ampstart-card" alt="Animation showing native sharing sheet appearing" src="/img/system-share.gif" width="270" height="480"></amp-img>
+  <amp-img class="ampstart-card" alt="Animation showing native sharing sheet
+  appearing" src="/img/system-share.gif" width="270" height="480"></amp-img>
   -->
 
   <amp-social-share type="system"></amp-social-share>


### PR DESCRIPTION
This is supported without an origin trial token [in Chrome 64](https://caniuse.com/#feat=web-share). (Pretty sure this applies to a few prior versions too.)