### PR TITLE
Fix invalid meta description tags in internationalization samples

### DIFF
--- a/static/internationalization/alternate/fr/index.amp.html
+++ b/static/internationalization/alternate/fr/index.amp.html
@@ -2,7 +2,7 @@
 <html ⚡>
   <head>
     <title>Example: French AMP Document</title>
-    <meta name="description">Internationalization example of site structures using hreflang with canonical, mobile and AMP documents.</meta>
+    <meta name="description" content="Internationalization example of site structures using hreflang with canonical, mobile and AMP documents." />
 
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/static/internationalization/alternate/fr/index.html
+++ b/static/internationalization/alternate/fr/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>Example: French Desktop Document</title>
-    <meta name="description">Internationalization example of site structures using hreflang with canonical, mobile and AMP documents.</meta>
+    <meta name="description" content="Internationalization example of site structures using hreflang with canonical, mobile and AMP documents." />
 
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>

--- a/static/internationalization/alternate/fr/index.mobile.html
+++ b/static/internationalization/alternate/fr/index.mobile.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>Example: French Mobile Document</title>
-    <meta name="description">Internationalization example of site structures using hreflang with canonical, mobile and AMP documents.</meta>
+    <meta name="description" content="Internationalization example of site structures using hreflang with canonical, mobile and AMP documents." />
 
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>

--- a/static/internationalization/alternate/index.amp.html
+++ b/static/internationalization/alternate/index.amp.html
@@ -2,7 +2,7 @@
 <html ⚡>
   <head>
     <title>Example: English AMP Document</title>
-    <meta name="description">Internationalization example of site structures using hreflang with canonical, mobile and AMP documents.</meta>
+    <meta name="description" content="Internationalization example of site structures using hreflang with canonical, mobile and AMP documents." />
 
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/static/internationalization/alternate/index.html
+++ b/static/internationalization/alternate/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>Example: English Desktop Document</title>
-    <meta name="description">Internationalization example of site structures using hreflang with canonical, mobile and AMP documents.</meta>
+    <meta name="description" content="Internationalization example of site structures using hreflang with canonical, mobile and AMP documents." />
 
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>

--- a/static/internationalization/alternate/index.mobile.html
+++ b/static/internationalization/alternate/index.mobile.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>Example: English Mobile Document</title>
-    <meta name="description">Internationalization example of site structures using hreflang with canonical, mobile and AMP documents.</meta>
+    <meta name="description" content="Internationalization example of site structures using hreflang with canonical, mobile and AMP documents." />
 
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>

--- a/static/internationalization/alternate/ja/index.amp.html
+++ b/static/internationalization/alternate/ja/index.amp.html
@@ -2,7 +2,7 @@
 <html ⚡>
   <head>
     <title>例：日本語のAMPページ</title>
-    <meta name="description" content="を使って正規ページ、モバイルページ、AMPページがあるサイトの i18n の例"></meta>
+    <meta name="description" content="hreflang を使って正規ページ、モバイルページ、AMPページがあるサイトの i18n の例"></meta>
 
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/static/internationalization/alternate/ja/index.html
+++ b/static/internationalization/alternate/ja/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>例：日本語のPC用ページ</title>
-    <meta name="description">hreflang を使って正規ページ、モバイルページ、AMPページがあるサイトの i18n の例</meta>
+    <meta name="description" content="hreflang を使って正規ページ、モバイルページ、AMPページがあるサイトの i18n の例" />
 
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>

--- a/static/internationalization/alternate/ja/index.mobile.html
+++ b/static/internationalization/alternate/ja/index.mobile.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>例：日本語のモバイルページ</title>
-    <meta name="description">hreflang を使って正規ページ、モバイルページ、AMPページがあるサイトの i18n の例</meta>
+    <meta name="description" content="hreflang を使って正規ページ、モバイルページ、AMPページがあるサイトの i18n の例" />
 
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>

--- a/static/internationalization/basic/fr/index.amp.html
+++ b/static/internationalization/basic/fr/index.amp.html
@@ -2,7 +2,7 @@
 <html ⚡>
   <head>
     <title>Example: French AMP Document</title>
-    <meta name="description">Internationalization example of site structures using hreflang with canonical, mobile and AMP documents.</meta>
+    <meta name="description" content="Internationalization example of site structures using hreflang with canonical, mobile and AMP documents." />
 
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/static/internationalization/basic/fr/index.html
+++ b/static/internationalization/basic/fr/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>Example: French Desktop Document</title>
-    <meta name="description">Internationalization example of site structures using hreflang with canonical, mobile and AMP documents.</meta>
+    <meta name="description" content="Internationalization example of site structures using hreflang with canonical, mobile and AMP documents." />
 
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>

--- a/static/internationalization/basic/index.amp.html
+++ b/static/internationalization/basic/index.amp.html
@@ -2,7 +2,7 @@
 <html ⚡>
   <head>
     <title>Example: English AMP Document</title>
-    <meta name="description" content="Internationalization example of site structures using hreflang with canonical, mobile and AMP documents."></meta>
+    <meta name="description" content="Internationalization example of site structures using hreflang with canonical, mobile and AMP documents." />
 
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/static/internationalization/basic/index.html
+++ b/static/internationalization/basic/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>Example: English Desktop Document</title>
-    <meta name="description">Internationalization example of site structures using hreflang with canonical, mobile and AMP documents.</meta>
+    <meta name="description" content="Internationalization example of site structures using hreflang with canonical, mobile and AMP documents." />
 
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>

--- a/static/internationalization/basic/ja/index.amp.html
+++ b/static/internationalization/basic/ja/index.amp.html
@@ -2,7 +2,7 @@
 <html ⚡>
   <head>
     <title>例：日本語のAMPページ</title>
-    <meta name="description">hreflang を使って正規ページ、モバイルページ、AMPページがあるサイトの i18n の例</meta>
+    <meta name="description" content="hreflang を使って正規ページ、モバイルページ、AMPページがあるサイトの i18n の例" />
 
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/static/internationalization/basic/ja/index.html
+++ b/static/internationalization/basic/ja/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>日本語のPC用ページ</title>
-    <meta name="description">hreflang を使って正規ページ、モバイルページ、AMPページがあるサイトの i18n の例</meta>
+    <meta name="description" content="hreflang を使って正規ページ、モバイルページ、AMPページがあるサイトの i18n の例" />
 
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>


### PR DESCRIPTION
Updated all internationalization examples to use content attribute on meta description tags.