### PR TITLE
Updated internationalization samples to include lang attribute

### DIFF
--- a/static/internationalization/alternate/fr/index.amp.html
+++ b/static/internationalization/alternate/fr/index.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="fr">
   <head>
     <title>Example: French AMP Document</title>
     <meta name="description" content="Internationalization example of site structures using hreflang with canonical, mobile and AMP documents." />

--- a/static/internationalization/alternate/fr/index.html
+++ b/static/internationalization/alternate/fr/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="fr">
   <head>
     <title>Example: French Desktop Document</title>
     <meta name="description" content="Internationalization example of site structures using hreflang with canonical, mobile and AMP documents." />

--- a/static/internationalization/alternate/fr/index.mobile.html
+++ b/static/internationalization/alternate/fr/index.mobile.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="fr">
   <head>
     <title>Example: French Mobile Document</title>
     <meta name="description" content="Internationalization example of site structures using hreflang with canonical, mobile and AMP documents." />

--- a/static/internationalization/alternate/index.amp.html
+++ b/static/internationalization/alternate/index.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <title>Example: English AMP Document</title>
     <meta name="description" content="Internationalization example of site structures using hreflang with canonical, mobile and AMP documents." />

--- a/static/internationalization/alternate/index.html
+++ b/static/internationalization/alternate/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
   <head>
     <title>Example: English Desktop Document</title>
     <meta name="description" content="Internationalization example of site structures using hreflang with canonical, mobile and AMP documents." />

--- a/static/internationalization/alternate/index.mobile.html
+++ b/static/internationalization/alternate/index.mobile.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
   <head>
     <title>Example: English Mobile Document</title>
     <meta name="description" content="Internationalization example of site structures using hreflang with canonical, mobile and AMP documents." />

--- a/static/internationalization/alternate/ja/index.amp.html
+++ b/static/internationalization/alternate/ja/index.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="ja">
   <head>
     <title>例：日本語のAMPページ</title>
     <meta name="description" content="hreflang を使って正規ページ、モバイルページ、AMPページがあるサイトの i18n の例"></meta>

--- a/static/internationalization/alternate/ja/index.html
+++ b/static/internationalization/alternate/ja/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="ja">
   <head>
     <title>例：日本語のPC用ページ</title>
     <meta name="description" content="hreflang を使って正規ページ、モバイルページ、AMPページがあるサイトの i18n の例" />

--- a/static/internationalization/alternate/ja/index.mobile.html
+++ b/static/internationalization/alternate/ja/index.mobile.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="ja">
   <head>
     <title>例：日本語のモバイルページ</title>
     <meta name="description" content="hreflang を使って正規ページ、モバイルページ、AMPページがあるサイトの i18n の例" />

--- a/static/internationalization/basic/fr/index.amp.html
+++ b/static/internationalization/basic/fr/index.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="fr">
   <head>
     <title>Example: French AMP Document</title>
     <meta name="description" content="Internationalization example of site structures using hreflang with canonical, mobile and AMP documents." />

--- a/static/internationalization/basic/fr/index.html
+++ b/static/internationalization/basic/fr/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="fr">
   <head>
     <title>Example: French Desktop Document</title>
     <meta name="description" content="Internationalization example of site structures using hreflang with canonical, mobile and AMP documents." />

--- a/static/internationalization/basic/index.amp.html
+++ b/static/internationalization/basic/index.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <title>Example: English AMP Document</title>
     <meta name="description" content="Internationalization example of site structures using hreflang with canonical, mobile and AMP documents." />

--- a/static/internationalization/basic/index.html
+++ b/static/internationalization/basic/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
   <head>
     <title>Example: English Desktop Document</title>
     <meta name="description" content="Internationalization example of site structures using hreflang with canonical, mobile and AMP documents." />

--- a/static/internationalization/basic/ja/index.amp.html
+++ b/static/internationalization/basic/ja/index.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="ja">
   <head>
     <title>例：日本語のAMPページ</title>
     <meta name="description" content="hreflang を使って正規ページ、モバイルページ、AMPページがあるサイトの i18n の例" />

--- a/static/internationalization/basic/ja/index.html
+++ b/static/internationalization/basic/ja/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="ja">
   <head>
     <title>日本語のPC用ページ</title>
     <meta name="description" content="hreflang を使って正規ページ、モバイルページ、AMPページがあるサイトの i18n の例" />


### PR DESCRIPTION
Internationalization samples were actually missing the lang attribute on the HTML tags of all the documents. Added en, fr and ja for appropriate files.