### PR TITLE
Fixed bug in second demo with image slider and custom item

### DIFF
--- a/src/30_Advanced/Tab_Panels_with_amp-selector.html
+++ b/src/30_Advanced/Tab_Panels_with_amp-selector.html
@@ -89,17 +89,21 @@
     -->
     <amp-selector role="tablist" layout="container" class="ampTabContainer">
         <div role="tab" class="tabButton" selected option="a">Images</div>
-        <amp-carousel class="tabContent" height="300" layout="fixed-height" type="carousel">
-            <amp-img src="/img/image1.jpg" width="400" height="300" alt="a sample image"></amp-img>
-            <amp-img src="/img/image2.jpg" width="400" height="300" alt="another sample image"></amp-img>
-            <amp-img src="/img/image3.jpg" width="400" height="300" alt="and another sample image"></amp-img>
-        </amp-carousel>
+        <div role="tabpanel" class="tabContent">
+            <amp-carousel height="300" layout="fixed-height" type="carousel">
+                <amp-img src="/img/image1.jpg" width="400" height="300" alt="a sample image"></amp-img>
+                <amp-img src="/img/image2.jpg" width="400" height="300" alt="another sample image"></amp-img>
+                <amp-img src="/img/image3.jpg" width="400" height="300" alt="and another sample image"></amp-img>
+            </amp-carousel>
+        </div>
         <div role="tab" class="tabButton" option="b">Custom Elements</div>
-        <amp-carousel class="tabContent" height="300" layout="fixed-height" type="carousel">
-            <div class="itemCustom">Custom Item One</div>
-            <div class="itemCustom">Custom Item Two</div>
-            <div class="itemCustom">Custom Item Three</div>
-        </amp-carousel>
+        <div role="tabpanel" class="tabContent">
+            <amp-carousel height="300" layout="fixed-height" type="carousel">
+                <div class="itemCustom">Custom Item One</div>
+                <div class="itemCustom">Custom Item Two</div>
+                <div class="itemCustom">Custom Item Three</div>
+            </amp-carousel>
+        </div>
     </amp-selector>
     <!--
     #### Tab panels with varying heights


### PR DESCRIPTION
Both panel are displaying by default  - it's wrong behavior. Add wrappers for ``` <amp-carousel>```.