### PR TITLE
Serve random story-ad config

### DIFF
--- a/backend/amp-story-auto-ads.go
+++ b/backend/amp-story-auto-ads.go
@@ -1,0 +1,48 @@
+// Copyright Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backend
+
+import (
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"net/http"
+	"path"
+)
+
+const NUMBER_OF_CONFIGS = 2
+
+func InitAmpStoryAutoAds() {
+	http.HandleFunc("/json/amp-story-auto-ads/", serveRandomAdConfig)
+}
+
+func getConfigNumber() int {
+	return rand.Intn(NUMBER_OF_CONFIGS)
+}
+
+func serveRandomAdConfig(w http.ResponseWriter, r *http.Request) {
+	configNumber := getConfigNumber()
+	configName := fmt.Sprintf("amp-story-auto-ads-%v.json", configNumber)
+	filePath := path.Join(DIST_FOLDER, "json", configName)
+
+	json, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		panic(err)
+	}
+
+	EnableCors(w, r)
+	SetContentTypeJson(w)
+	w.Write(json)
+}

--- a/server.go
+++ b/server.go
@@ -46,6 +46,7 @@ func init() {
 	backend.InitAmpAccess()
 	backend.InitFavoriteSample()
 	backend.InitCheckout()
+	backend.InitAmpStoryAutoAds()
 	playground.InitPlayground()
 	http.Handle("/", ServeStaticFiles(HandleNotFound(http.FileServer(http.Dir(DIST_DIR)))))
 }

--- a/src/json/amp-story-auto-ads-0.json
+++ b/src/json/amp-story-auto-ads-0.json
@@ -1,0 +1,10 @@
+{
+  "templateId": "video-template",
+  "data": {
+    "videoSource": "https://i.imgur.com/4wUqhsQ.jpg"
+  },
+  "vars": {
+    "ctaType": "BUY",
+    "ctaUrl": "https://ampproject.org"
+  }
+}

--- a/src/json/amp-story-auto-ads-1.json
+++ b/src/json/amp-story-auto-ads-1.json
@@ -1,0 +1,10 @@
+{
+  "templateId": "image-template",
+  "data": {
+    "imgSrc": "https://i.imgur.com/4wUqhsQ.jpg"
+  },
+  "vars": {
+    "ctaType": "SHOP",
+    "ctaUrl": "https://ampproject.org"
+  }
+}


### PR DESCRIPTION
This is the start to the `amp-story-auto-ads` example. This extension hits a defined endpoint and expects that endpoint to return dynamic a JSON payload it will use to build the ad.

I made this endpoint `/json/amp-story-auto-ads` but happy to change it. Also added a couple of sample configs. These will be modified and more will be more added later. 

This is my first go code :) let me know if it can be improved.