### PR TITLE
Update to reflect allowed password in POST form

### DIFF
--- a/src/20_Components/amp-form.html
+++ b/src/20_Components/amp-form.html
@@ -290,7 +290,7 @@
 </form>
 <!-- ## Other form input samples -->
   <!--
-    `amp-form` supports all HTML5 form types with the exception of file, password and image.
+    `amp-form` supports all HTML5 form types with the exception of file, button and image.
     Use `type="date"` for input fields that should contain a date.
   -->
   <form method="post" class="p2" action-xhr="/components/amp-form/submit-form-xhr" target="_top">


### PR DESCRIPTION
We will allow password fields in AMP forms after https://github.com/ampproject/amphtml/pull/14533 validator changes reach the production validator. This was the only reference to passwords being forbidden, so I have updated it.