### PR TITLE
Tweak left and right columns on example view

### DIFF
--- a/templates/css/shared.css
+++ b/templates/css/shared.css
@@ -131,6 +131,8 @@ a.abe-primary {
 /* AMPSTART Tweaks **/
 .www-components-sec-nav {
   min-width: 200px;
+  margin-top: -4.5rem;
+  padding-top: 4.5rem;
 }
 .ampstart-card a:not(.ampstart-btn),
 .www-component-desc li a:not(.ampstart-btn),

--- a/templates/example.html
+++ b/templates/example.html
@@ -115,7 +115,7 @@
       {{/document.sections}}
 
     </article>
-    <aside class="col-2 xs-hide"></aside>
+    <aside class="col-2 xs-hide sm-hide md-hide"></aside>
   </main>
   {{#supportsAmpSelector}}
   </amp-selector>


### PR DESCRIPTION
The first commit only shows the spacer `<aside>` for large desktop-sized screens. This allows more real-estate on smaller but non-mobile-size windows for code to layout better.

description|before|after
--|--|--
"desktop size" looks the same|<img width="1155" alt="screen shot 2018-04-17 at 11 09 54" src="https://user-images.githubusercontent.com/2363700/39146109-a484f692-46ea-11e8-8868-e5d09c48948e.png">|<img width="1155" alt="screen shot 2018-04-17 at 11 09 57" src="https://user-images.githubusercontent.com/2363700/39146114-a5a3dcaa-46ea-11e8-8934-e59824501d80.png">
"tablet size" has wasted space on right|<img width="100%" alt="screen shot 2018-04-17 at 11 08 37" src="https://user-images.githubusercontent.com/2363700/39145925-217f5d96-46ea-11e8-8133-f9ead2cf9421.png">|<img width="100%" alt="screen shot 2018-04-17 at 11 08 40" src="https://user-images.githubusercontent.com/2363700/39145927-2311da08-46ea-11e8-86e5-c86c28a59566.png">
"mobile size" has confusing extra space on right |<img width="100%" alt="screen shot 2018-04-17 at 11 11 13" src="https://user-images.githubusercontent.com/2363700/39146026-663ba606-46ea-11e8-8491-2ec9f5c28b1e.png">|<img width="100%" alt="screen shot 2018-04-17 at 11 11 15" src="https://user-images.githubusercontent.com/2363700/39146028-67b49128-46ea-11e8-9379-adccfb13c7f5.png">

The second commit fixes the left column shadow appearing over top the red diagonal line 

before|after
--|--
<img width="100%" alt="screen shot 2018-04-23 at 12 37 39" src="https://user-images.githubusercontent.com/2363700/39149194-36b99718-46f3-11e8-8e1c-01d4e426f409.png">|<img width="100%" alt="screen shot 2018-04-23 at 12 37 44" src="https://user-images.githubusercontent.com/2363700/39149204-3cf3e5ac-46f3-11e8-8ded-0cf9bf6df074.png">


