### PR TITLE
"Line" type added to amp-social-share.

### DIFF
--- a/src/20_Components/amp-social-share.html
+++ b/src/20_Components/amp-social-share.html
@@ -58,6 +58,7 @@
     <amp-social-share type="tumblr"></amp-social-share>
     <amp-social-share type="twitter"></amp-social-share>
     <amp-social-share type="whatsapp"></amp-social-share>
+    <amp-social-share type="line"></amp-social-share>
   </div>
 
   <!-- ## Configuration -->
@@ -106,6 +107,7 @@
     <amp-social-share class="rounded" type="tumblr" width="36" height="36"></amp-social-share>
     <amp-social-share class="rounded" type="twitter" width="36" height="36"></amp-social-share>
     <amp-social-share class="rounded" type="whatsapp" width="36" height="36"></amp-social-share>
+    <amp-social-share class="rounded" type="line" width="36" height="36"></amp-social-share>
   </div>
 
 


### PR DESCRIPTION
Added the line type of amp-social-share, released the other day, to example.

https://github.com/ampproject/amphtml/releases/tag/1525461683159