### PR TITLE
All images in caption group should belong to same lightbox group

### DIFF
--- a/src/20_Components/amp-lightbox-gallery.html
+++ b/src/20_Components/amp-lightbox-gallery.html
@@ -122,11 +122,21 @@ The amp-lightbox-gallery component provides a "lightbox” experience for AMP co
   -->
   <div class="container">
 
-    <amp-img lightbox src="/img/road-1.jpg" width="300" height="200" layout="responsive"></amp-img>
+    <amp-img
+      lightbox="caption"
+      src="/img/road-1.jpg"
+      width="300"
+      height="200"
+      layout="responsive"></amp-img>
     <p class="paragraph">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
 
     <figure>
-      <amp-img lightbox src="/img/road-2.jpg" width="300" height="200" layout="responsive"></amp-img>
+      <amp-img
+        lightbox="caption"
+        src="/img/road-2.jpg"
+        width="300"
+        height="200"
+        layout="responsive"></amp-img>
       <figcaption class="image">
         This is a long road. We don't know where it leads.
       </figcaption>


### PR DESCRIPTION
Fix an issue with the last example, where the images in the same group should be assigned to the same lightbox group. 