### PR TITLE
Update amp-story bookend attribute

### DIFF
--- a/src/stories/30_Monetization/amp-story-auto-ads.html
+++ b/src/stories/30_Monetization/amp-story-auto-ads.html
@@ -126,7 +126,8 @@
       title="Key Highlights of AMP Conf 2018"
       publisher="The AMP team"
       publisher-logo-src="<%host%>/img/AMP-Brand-White-Icon.svg"
-      poster-portrait-src="<%host%>/img/overview.jpg">
+      poster-portrait-src="<%host%>/img/overview.jpg"
+      bookend-config-src="<%host%>/json/bookend.json">
       <!-- ## Configuration -->
       <!-- Include the `amp-story-auto-ads` tag on your page. -->
       <!-- It's first child should be a `script` tag with a JSON configuration object
@@ -366,8 +367,6 @@
           </a>
         </amp-story-cta-layer>
       </amp-story-page>
-
-      <amp-story-bookend src="<%host%>/json/bookend.json"></amp-story-bookend>
     </amp-story>
   </body>
 </html>

--- a/src/stories/30_Monetization/amp-story-auto-ads.html
+++ b/src/stories/30_Monetization/amp-story-auto-ads.html
@@ -126,8 +126,7 @@
       title="Key Highlights of AMP Conf 2018"
       publisher="The AMP team"
       publisher-logo-src="<%host%>/img/AMP-Brand-White-Icon.svg"
-      poster-portrait-src="<%host%>/img/overview.jpg"
-      bookend-config-src="<%host%>/json/bookend.json">
+      poster-portrait-src="<%host%>/img/overview.jpg">
       <!-- ## Configuration -->
       <!-- Include the `amp-story-auto-ads` tag on your page. -->
       <!-- It's first child should be a `script` tag with a JSON configuration object
@@ -367,6 +366,8 @@
           </a>
         </amp-story-cta-layer>
       </amp-story-page>
+
+      <amp-story-bookend src="<%host%>/json/bookend.json" layout="nodisplay"></amp-story-bookend>
     </amp-story>
   </body>
 </html>


### PR DESCRIPTION
It seems that the lack of a `layout` attribute in `amp-story-bookend` is causing CI to fail.

If I understand correctly, we can just remove this element all together and use the `bookend-config-src` attribute instead to the same effect.