### PR TITLE
Add examples for amp-accordion's new attributes

### DIFF
--- a/src/20_Components/amp-accordion.html
+++ b/src/20_Components/amp-accordion.html
@@ -130,5 +130,47 @@
         </amp-accordion>
       </section>
     </amp-accordion>
+
+    <!-- ## Auto-Collapsing Accordions -->
+
+    <!-- The `expand-single-section` attribute forces the accordion to only allow one expanded section at any given time. Expanding one section will cause any other open sections to close. -->
+
+    <amp-accordion expand-single-section>
+      <section>
+        <h4>Section 1</h4>
+        <p>Id lacus amet. Aliquam eos nunc ut scelerisque lacinia, eu rutrum id, vestibulum aliqua vivamus luctus eu rhoncus ut, sodales id. Velit lacus, fermentum neque et sagittis, ac venenatis volutpat, dolore neque feugiat proin fermentum odio, odio arcu in eu wisi. </p>
+      </section>
+      <section>
+        <h4>Section 2</h4>
+        <p>Id lacus amet. Aliquam eos nunc ut scelerisque lacinia, eu rutrum id, vestibulum aliqua vivamus luctus eu rhoncus ut, sodales id. Velit lacus, fermentum neque et sagittis, ac venenatis volutpat, dolore neque feugiat proin fermentum odio, odio arcu in eu wisi. </p>
+      </section>
+      <section>
+        <h4>Section 3</h4>
+        <p>Id lacus amet. Aliquam eos nunc ut scelerisque lacinia, eu rutrum id, vestibulum aliqua vivamus luctus eu rhoncus ut, sodales id. Velit lacus, fermentum neque et sagittis, ac venenatis volutpat, dolore neque feugiat proin fermentum odio, odio arcu in eu wisi. </p>
+      </section>
+    </amp-accordion>
+
+        <!-- ## Animated Accordions -->
+
+    <!-- The `animate` attribute animates the expansion and collapse of accordion sections. -->
+
+    <amp-accordion animate>
+      <section>
+        <h4>Section 1</h4>
+        <p>Id lacus amet. Aliquam eos nunc ut scelerisque lacinia, eu rutrum id, vestibulum aliqua vivamus luctus eu rhoncus ut, sodales id. Velit lacus, fermentum neque et sagittis, ac venenatis volutpat, dolore neque feugiat proin fermentum odio, odio arcu in eu wisi. </p>
+      </section>
+      <section>
+        <h4>Section 2</h4>
+        <amp-img src="/img/clean-1.jpg"
+          layout="responsive"
+          width="400"
+          height="710"></amp-img>
+      </section>
+      <section>
+        <h4>Section 3</h4>
+        <p>Id lacus amet. Aliquam eos nunc ut scelerisque lacinia, eu rutrum id, vestibulum aliqua vivamus luctus eu rhoncus ut, sodales id. Velit lacus, fermentum neque et sagittis, ac venenatis volutpat, dolore neque feugiat proin fermentum odio, odio arcu in eu wisi. </p>
+      </section>
+    </amp-accordion>
+
 </body>
 </html>


### PR DESCRIPTION
We recently added the `animate` and `expand-single-section` attributes to `<amp-accordion>` per https://github.com/ampproject/amphtml/pull/15460 and https://github.com/ampproject/amphtml/pull/13364. Updating ABE to include an example for each. 