### PR TITLE
Remove the auto-advance-parameter from the amp-story-consent example.

### DIFF
--- a/src/stories/50_User_Consent/Story_User_Consent.html
+++ b/src/stories/50_User_Consent/Story_User_Consent.html
@@ -121,7 +121,7 @@
         </amp-story-consent>
       </amp-consent>
 
-      <amp-story-page id="page-1"  auto-advance-after="1s">
+      <amp-story-page id="page-1">
         <amp-story-grid-layer template="fill">
           <amp-video autoplay loop
             width="400"


### PR DESCRIPTION
The attribute `auto-advance-after="1s"` was causing a confusing behavior where the story would automatically jump to the next page after one second.
New behavior will loop the video and wait for a user interaction to navigate.

Fixes #1323 
