### PR TITLE
Remove amp-date-picker experiment

### DIFF
--- a/src/20_Components/amp-date-picker.html
+++ b/src/20_Components/amp-date-picker.html
@@ -1,6 +1,3 @@
-<!---{
-    "experiments": ["amp-date-picker"]
-}--->
 <!doctype html>
 <html ⚡>
 <head>


### PR DESCRIPTION
To be merged/deployed when the removal of the experiment is out of canary and in prod