### PR TITLE
Add logic for creating hidable "hints" in sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,26 @@ You can use [markdown](https://help.github.com/articles/github-flavored-markdown
 <amp-img src="img/image1.jpg" width="200" height="100" layout="responsive"></amp-img>
 ```
 
+#### Hints
+
+If you'd like to add additional information about a single element inside a section, use the `<!--~ hint syntax ~-->`:
+
+```html
+<!-- A comment about the form. -->
+<form method="post"
+  action-xhr="https://example.com/subscribe"
+  target="_top">
+  <fieldset>
+    <input type="text" name="username">
+
+    <!--~ Addition explanation about the hidden field. ~-->
+    <input type="hidden" name="id" value="abc">
+  </fieldset>
+</form>
+```
+
+This will make the `<input>` element clickable, with the additional explanation appearing on click.
+
 #### Drafts
 
 You can mark samples as drafts if they are still work-in-progress. This means the samples won't show up in the start page.
@@ -227,8 +247,8 @@ If you need to run or write a sample that depends on the backend server, you can
     # install the google.goland.org/appengine package
     $ go get google.golang.org/appengine
     # explicitly set the GOROOT and APPENGINE_DEV_APPSERVER env vars
-    $ export GOROOT=$HOME/local/google-cloud-sdk/platform/google_appengine/goroot 
-    $ export APPENGINE_DEV_APPSERVER=$(which dev_appserver.py) 
+    $ export GOROOT=$HOME/local/google-cloud-sdk/platform/google_appengine/goroot
+    $ export APPENGINE_DEV_APPSERVER=$(which dev_appserver.py)
     ```
 
 3. If everything went well, the full site should now be running on <http://localhost:8080/>

--- a/lib/CodeSection.js
+++ b/lib/CodeSection.js
@@ -95,7 +95,7 @@ module.exports = class CodeSection {
   }
 
   appendHint(hint) {
-    if (this.currentHint === '') {
+    if (!this.currentHint) {
       this.appendCode(`<!--${hintStartPlaceholder}_${this.hints.length}-->`);
     }
     this.currentHint += hint;

--- a/lib/CodeSection.js
+++ b/lib/CodeSection.js
@@ -17,7 +17,7 @@
 "use strict";
 
 const S = require('string');
-const highlight = require('highlight.js').highlight;
+const hljs = require('highlight.js');
 const marked = require('marked');
 const renderer = new marked.Renderer();
 renderer.heading = function (text, level) {
@@ -32,10 +32,20 @@ renderer.paragraph = function (text) {
 
 const encodedTemplateRegexp = /\[\[\s*<.*?>([A-Za-z]*?)\s*(<.*?>)?(\.[A-Za-z]*)?\s*<\/span>\s*\]\]/g
 
+const hintStartPlaceholder = 'START_HINT';
+const hintStartRegexp = new RegExp(`<span class="hljs-comment">&lt;!--${hintStartPlaceholder}_(\\d+)--&gt;</span>\\n?`, 'g');
+const hintEndPlaceholder = 'END_HINT';
+const hintEndRegexp = new RegExp(`<span class="hljs-comment">&lt;!--${hintEndPlaceholder}--&gt;</span>\\n?`, 'g');
+
+// `${hintStartHtmlOpen} <hint text> ${hintStartHtmlClose} <element> ${hintEndHtml}`
+const hintStartHtmlOpen = '<label class="has-hint"><input class="show-hint" type="checkbox"><div class="hint">';
+const hintStartHtmlClose = '</div>';
+const hintEndHtml = '</label>';
+
 marked.setOptions({
   highlight: function(code, lang) {
     if (lang) {
-      return highlight(lang, code).value;
+      return hljs.highlight(lang, code).value;
     } else {
       return S(code).escapeHTML().s;
     }
@@ -65,6 +75,8 @@ module.exports = class CodeSection {
     this.codeOffset = 0;
     this.headings = [];
     this.storyPageId = '';
+    this.currentHint = '';
+    this.hints = [];
   }
 
   appendDoc(doc) {
@@ -82,12 +94,27 @@ module.exports = class CodeSection {
     this.code += code.substring(startIndex) + '\n';
   }
 
+  appendHint(hint) {
+    if (this.currentHint === '') {
+      this.appendCode(`<!--${hintStartPlaceholder}_${this.hints.length}-->`);
+    }
+    this.currentHint += hint;
+  }
+
+  endHint() {
+    let hint = this.currentHint.replace(/<!--~(.*?)~-->/, '$1')
+    hint = hint.replace(/\s+/g, ' ').trim();
+    this.hints.push(hint);
+    this.currentHint = '';
+    this.appendCode(`<!--${hintEndPlaceholder}-->`);
+  }
+
   appendPreview(code) {
     this.preview += code + '\n';
   }
 
   escapedCode() {
-    const result = highlight('html', this.codeSnippet()).value;
+    const result = this.highlight('html', this.codeSnippet());
     return this.cleanUpCode(result);
   }
 
@@ -150,7 +177,7 @@ module.exports = class CodeSection {
   normalizeDoc(string) {
     let startIndex = string.indexOf(COMMENT_START);
     if (startIndex == -1) {
-      startIndex = 
+      startIndex =
         this.stripLeadingWhitespace(string, this.commentOffset);
     } else {
       this.commentOffset = startIndex;
@@ -203,6 +230,20 @@ module.exports = class CodeSection {
       name: name
     };
     this.headings.push(heading);
-  };
-};
+  }
 
+  replaceHints(html) {
+    const result = html.replace(hintStartRegexp, (matches, id) => {
+      id = Number(id);
+      const hint = this.hints[id];
+      return `${hintStartHtmlOpen}${hint}${hintStartHtmlClose}`;
+    });
+    return result.replace(hintEndRegexp, hintEndHtml);
+  }
+
+  highlight(name, value) {
+    let result = hljs.highlight(name, value).value;
+    result = this.replaceHints(result);
+    return result;
+  }
+};

--- a/lib/DocumentParser.js
+++ b/lib/DocumentParser.js
@@ -22,6 +22,8 @@ const elementSorting = require('./ElementSorting');
 const beautifyHtml = require('js-beautify').html;
 
 const SINGLE_LINE_TAGS = ['link', 'meta', '!doctype'];
+const VOID_TAGS = ['area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input',
+                   'link', 'meta', 'param', 'source', 'track', 'wbr'];
 
 const SAMPLE_THUMBNAIL = '/favicons/android-chrome-256x256.png';
 const DEFAULT_LANG = 'en';
@@ -65,6 +67,8 @@ class DocumentParser {
     this.currentTagCounter = 0;
     this.inBody = false;
     this.inMetadata = false;
+    this.inHint = false;
+    this.inHintedElement = false;
     this.metadata = '';
   }
 
@@ -75,6 +79,8 @@ class DocumentParser {
       if (trimmedLine.startsWith('<!--')) {
         if (trimmedLine.startsWith('<!---')) {
           this.inMetadata = true;
+        } else if (trimmedLine.startsWith('<!--~')) {
+          this.inHint = true;
         } else {
           this.newSection();
           this.inComment = true;
@@ -86,7 +92,10 @@ class DocumentParser {
       if (this.inMetadata) {
         this.appendMetadata(line);
       }
-      if (!this.inComment && !this.inMetadata) {
+      if (this.inHint) {
+        this.currentSection().appendHint(line);
+      }
+      if (!this.inComment && !this.inMetadata && !this.inHint) {
         this.updatePreview(line);
         this.currentSection().appendCode(line);
         this.updateHtmlTag(line);
@@ -94,7 +103,12 @@ class DocumentParser {
         this.updateStory(line);
         if (this.endOfCurrentTag(line)) {
           // console.log("end tag: " + this.currentTag);
-          this.endSection();
+          if (this.inHintedElement) {
+            this.currentSection().endHint();
+            this.inHintedElement = false;
+          } else {
+            this.endSection();
+          }
           this.currentTag = '';
         }
       }
@@ -105,10 +119,14 @@ class DocumentParser {
             this.document.metadata = JSON.parse(this.metadata);
           } catch (err) {
             throw new Error(
-              "There is an error in the JSON metadata at line " + (i + 1) + 
+              "There is an error in the JSON metadata at line " + (i + 1) +
                 '\n' + '"' + line + '"', err);
           }
-        } else {
+        } else if (trimmedLine.endsWith('~-->')) {
+          this.inHint = false;
+          this.inHintedElement = true;
+          this.currentTag = this.nextTag(i);
+        } else if (this.inComment) {
           this.inComment = false;
           this.currentTag = this.nextTag(i);
           //console.log("start tag: " + this.currentTag);
@@ -188,6 +206,9 @@ class DocumentParser {
 
     const tag = this.extractTag(line);
     if (SINGLE_LINE_TAGS.indexOf(tag) > -1) {
+      return true;
+    }
+    if (VOID_TAGS.indexOf(this.currentTag) > -1 && line.trim().endsWith('>')) {
       return true;
     }
     if (tag == this.currentTag) {

--- a/spec/compiler/DocumentParserSpec.js
+++ b/spec/compiler/DocumentParserSpec.js
@@ -38,8 +38,10 @@ describe("DocumentParser", function() {
   <div>hello</div>
 </div>`.trim();
   var COMMENT = '<!--comment-->';
+  var HINT = '<!--~hint~-->';
   var LINK = ' <link href="Hello World" />';
   var META = ' <meta href="Hello World" />';
+  var BASE = ' <base href="/">';
   var DOCUMENT_METADATA = `<!---{
     "experiments": ["amp-accordion"]
   }--->`;
@@ -62,6 +64,19 @@ describe("DocumentParser", function() {
       .toEqual([
           newSection('comment\n', TAG + '\n', "", true, true),
       ]);
+  });
+
+  it("adds hint", function() {
+    const expected = newSection(
+      '',
+      `<!--START_HINT_0-->\n${TAG}\n<!--END_HINT-->\n`,
+      '',
+      true,
+      true
+    );
+    expected.hints = ['hint'];
+
+    expect(parse(HINT, TAG).sections).toEqual([expected]);
   });
 
   it("supports wrapped attributes", function() {
@@ -140,6 +155,13 @@ describe("DocumentParser", function() {
     });
   });
 
+  describe("void tags", function() {
+    it("base", function() {
+      var doc = parse(HEAD, COMMENT, BASE, TITLE, HEAD_END);
+      expect(doc.sections.length).toEqual(3);
+    });
+  });
+
   it("adds title to document", function() {
     var doc = parse(HEAD, TITLE, HEAD_END);
     expect(doc.title).toEqual('hello');
@@ -177,6 +199,7 @@ describe("DocumentParser", function() {
       expect(parser.extractTag('<!--- -->')).toEqual('');
       expect(parser.extractTag('  <h4>Hello World</h4>')).toEqual('h4');
       expect(parser.extractTag('<amp-ad width="300"')).toEqual('amp-ad');
+      expect(parser.extractTag('<input type="text">')).toEqual('input');
     });
 
     it("end tag", function() {

--- a/spec/compiler/DocumentParserSpec.js
+++ b/spec/compiler/DocumentParserSpec.js
@@ -155,7 +155,7 @@ describe("DocumentParser", function() {
     });
   });
 
-  describe("void tags", function() {
+  describe("ends void tags automatically", function() {
     it("base", function() {
       var doc = parse(HEAD, COMMENT, BASE, TITLE, HEAD_END);
       expect(doc.sections.length).toEqual(3);

--- a/src/60_Samples_%26_Templates/Product_Browse_Page.html
+++ b/src/60_Samples_%26_Templates/Product_Browse_Page.html
@@ -147,9 +147,8 @@ article#preview {
         <a class="caps text-decoration-none block p1" href="/samples_templates/product_browse_page/preview/">More</a>
       </amp-sidebar>
       <!-- ## Header with Search -->
-
-      <!-- AMP supports forms, which means you can directly integrate a product search into your AMPs. 
-        Here we implemented autosuggest, try searching for "Apple" and you should be able to select "Apple". 
+      <!-- AMP supports forms, which means you can directly integrate a product search into your AMPs.
+        Here we implemented autosuggest, try searching for "Apple" and you should be able to select "Apple".
         Take a look at [autosuggest sample](/advanced/autosuggest/) for more details how autosuggest is implemented.
         AMP doesn't support custom Javascript, but you can use CSS3 animations to enrich your page. The expanding text field when the search box is focused is implemented with CSS only. -->
       <div class="header">
@@ -225,7 +224,7 @@ article#preview {
               </amp-list>
             </div>
           </div>
-        <!-- Keep this just for creating the change event -->
+        <!--~ Keep this just for creating the change event ~-->
         <input type="submit" value="">
       </div>
       <!-- ## A Hero Slider -->

--- a/templates/css/example.css
+++ b/templates/css/example.css
@@ -177,22 +177,21 @@ code {
 .abe-code .has-hint > .hint {
   position: absolute;
   bottom: 100%;
-  border-radius: 5px;
-  padding: 0.5rem;
+  padding: 1rem;
   width: 100%;
   margin-bottom: 7px;
-  background: #fff;
+  background: #fffde7;
   color: transparent;
   line-height: 1.5rem;
   font-family: var(--font-family-serif);
-  box-shadow: 0 0 1px 0 rgba(50,68,78,.5), 0 0 2px 0 rgba(0,0,0,.07), 0 3px 8px 0 rgba(0,0,0,.1);
+  box-shadow: 0 1px 1px 0 rgba(0,0,0,.14), 0 1px 1px -1px rgba(0,0,0,.14), 0 1px 5px 0 rgba(0,0,0,.12);
   transform: scaleY(0);
-  transition: transform .7s, color .3s;
+  transition: transform .25s ease-in-out, color .1s;
   transform-origin: bottom;
   user-select: none;
 }
 .abe-code .has-hint > .hint:before {
-  content: "🗙";
+  content: "❌";
   position: absolute;
   right: 7px;
   top: 7px;

--- a/templates/css/example.css
+++ b/templates/css/example.css
@@ -152,3 +152,47 @@ code {
 .abe-preview>p {
   padding: 1rem;
 }
+.abe-code .has-hint {
+  display: block;
+  position: relative;
+  cursor: pointer;
+  background-color: rgba(132, 183, 232, 0.25);
+  border-radius: 5px;
+  transition: background-color .3s;
+}
+.abe-code .has-hint:hover {
+  background-color: rgba(132, 183, 232, 0.5);
+}
+.abe-code .has-hint:before {
+  content: "🛈";
+  position: absolute;
+  right: 7px;
+  top: 7px;
+  font-size: 1.3em;
+}
+.abe-code .has-hint > .hint {
+  opacity: 0;
+  position: absolute;
+  top: 100%;
+  border-radius: 5px;
+  padding: 5px;
+  width: 100%;
+  text-align: center;
+  margin-top: 3px;
+  background: #fff;
+  color: #4a4a4a;
+  line-height: 1.5rem;
+  font-family: Montserrat,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,Arial,sans-serif;
+  box-shadow: 0 0 1px 0 rgba(50,68,78,.5), 0 0 2px 0 rgba(0,0,0,.07), 0 3px 8px 0 rgba(0,0,0,.1);
+  transform: scale(0);
+  transition: transform .7s, opacity .7s;
+  transform-origin: top;
+  user-select: none;
+}
+.abe-code .has-hint > .show-hint {
+  display: none;
+}
+.abe-code .has-hint > .show-hint:checked + .hint {
+  opacity: 1;
+  transform: scale(1);
+}

--- a/templates/css/example.css
+++ b/templates/css/example.css
@@ -156,43 +156,53 @@ code {
   display: block;
   position: relative;
   cursor: pointer;
-  background-color: rgba(132, 183, 232, 0.25);
+  background-color: #eb407a18;
   border-radius: 5px;
   transition: background-color .3s;
+  padding: 0.5rem 0;
+  margin: 0.5rem 0;
 }
 .abe-code .has-hint:hover {
-  background-color: rgba(132, 183, 232, 0.5);
+  background-color: #eb407a28;
 }
 .abe-code .has-hint:before {
-  content: "💡";
+  content: " ";
+  background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z" fill="#eb407a"/></svg>') no-repeat;
   position: absolute;
-  right: 7px;
-  top: 7px;
-  font-size: 1.3em;
+  right: 5px;
+  top: 5px;
+  width: 24px;
+  height: 24px;
 }
 .abe-code .has-hint > .hint {
-  opacity: 0;
   position: absolute;
   bottom: 100%;
   border-radius: 5px;
-  padding: 5px;
+  padding: 0.5rem;
   width: 100%;
-  text-align: center;
   margin-bottom: 7px;
   background: #fff;
-  color: #4a4a4a;
+  color: transparent;
   line-height: 1.5rem;
   font-family: var(--font-family-serif);
   box-shadow: 0 0 1px 0 rgba(50,68,78,.5), 0 0 2px 0 rgba(0,0,0,.07), 0 3px 8px 0 rgba(0,0,0,.1);
-  transform: scale(0);
-  transition: transform .7s, opacity .7s;
+  transform: scaleY(0);
+  transition: transform .7s, color .3s;
   transform-origin: bottom;
   user-select: none;
+}
+.abe-code .has-hint > .hint:before {
+  content: "🗙";
+  position: absolute;
+  right: 7px;
+  top: 7px;
+  font-size: 0.8em;
+  line-height: 10px;
 }
 .abe-code .has-hint > .show-hint {
   display: none;
 }
 .abe-code .has-hint > .show-hint:checked + .hint {
-  opacity: 1;
-  transform: scale(1);
+  color: #4a4a4a;
+  transform: scaleY(1);
 }

--- a/templates/css/example.css
+++ b/templates/css/example.css
@@ -177,26 +177,29 @@ code {
 .abe-code .has-hint > .hint {
   position: absolute;
   bottom: 100%;
+  border-radius: 5px;
   padding: 1rem;
   width: 100%;
   margin-bottom: 7px;
-  background: #fffde7;
+  background: #fff;
   color: transparent;
   line-height: 1.5rem;
   font-family: var(--font-family-serif);
-  box-shadow: 0 1px 1px 0 rgba(0,0,0,.14), 0 1px 1px -1px rgba(0,0,0,.14), 0 1px 5px 0 rgba(0,0,0,.12);
+  box-shadow: 0 0 1px 0 rgba(50,68,78,.5), 0 0 2px 0 rgba(0,0,0,.07), 0 3px 8px 0 rgba(0,0,0,.1);
   transform: scaleY(0);
   transition: transform .25s ease-in-out, color .1s;
   transform-origin: bottom;
   user-select: none;
 }
 .abe-code .has-hint > .hint:before {
-  content: "❌";
+  content: " ";
+  background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="#757575"><path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"/><path fill="none" d="M0 0h24v24H0V0z"/></svg>') no-repeat;
+  background-size: contain;
   position: absolute;
   right: 7px;
   top: 7px;
-  font-size: 0.8em;
-  line-height: 10px;
+  width: 16px;
+  height: 16px;
 }
 .abe-code .has-hint > .show-hint {
   display: none;

--- a/templates/css/example.css
+++ b/templates/css/example.css
@@ -173,12 +173,12 @@ code {
 .abe-code .has-hint > .hint {
   opacity: 0;
   position: absolute;
-  top: 100%;
+  bottom: 100%;
   border-radius: 5px;
   padding: 5px;
   width: 100%;
   text-align: center;
-  margin-top: 3px;
+  margin-bottom: 7px;
   background: #fff;
   color: #4a4a4a;
   line-height: 1.5rem;
@@ -186,7 +186,7 @@ code {
   box-shadow: 0 0 1px 0 rgba(50,68,78,.5), 0 0 2px 0 rgba(0,0,0,.07), 0 3px 8px 0 rgba(0,0,0,.1);
   transform: scale(0);
   transition: transform .7s, opacity .7s;
-  transform-origin: top;
+  transform-origin: bottom;
   user-select: none;
 }
 .abe-code .has-hint > .show-hint {

--- a/templates/css/example.css
+++ b/templates/css/example.css
@@ -7,7 +7,7 @@ amp-instagram {
 }
 .www-component-desc pre,
 pre, code {
-  font-family: Consolas,Menlo,Monaco,Lucida Console,Liberation Mono,DejaVu Sans Mono,Bitstream Vera Sans Mono,Courier New,monospace,sans-serif;
+  font-family: var(--font-family-monospace);
   font-size: 0.9rem;
   white-space: pre-wrap;
 }
@@ -164,7 +164,7 @@ code {
   background-color: rgba(132, 183, 232, 0.5);
 }
 .abe-code .has-hint:before {
-  content: "🛈";
+  content: "💡";
   position: absolute;
   right: 7px;
   top: 7px;
@@ -182,7 +182,7 @@ code {
   background: #fff;
   color: #4a4a4a;
   line-height: 1.5rem;
-  font-family: Montserrat,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,Arial,sans-serif;
+  font-family: var(--font-family-serif);
   box-shadow: 0 0 1px 0 rgba(50,68,78,.5), 0 0 2px 0 rgba(0,0,0,.07), 0 3px 8px 0 rgba(0,0,0,.1);
   transform: scale(0);
   transition: transform .7s, opacity .7s;

--- a/templates/css/shared.css
+++ b/templates/css/shared.css
@@ -1,8 +1,12 @@
+:root {
+  --font-family-serif: Montserrat,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,Arial,sans-serif;
+  --font-family-monospace: Consolas,Menlo,Monaco,Lucida Console,Liberation Mono,DejaVu Sans Mono,Bitstream Vera Sans Mono,Courier New,monospace,sans-serif;
+}
 * {
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
 }
 body {
-  font-family: Montserrat,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,Arial,sans-serif;
+  font-family: var(--font-family-serif);
 }
 a.abe-primary {
   color: #b60845;


### PR DESCRIPTION
# Adding "hint syntax" to AMP by Example

## Background

It seems useful for some samples to have a "callout" with additional information in a larger block of code that's only displayed when the user clicks on it.

An example of this is the [Google Maps Platform docs](https://developers.google.com/maps/documentation/javascript/tutorial#The_Hello_World_of_Google_Maps_v3) where `YOUR_API_KEY` is clickable. In the context of AMP, this can be useful to call out things that should be done server-side and shouldn't be copy-pasted directly (this came up for some AMPHTML Email samples that are WIP, but is probably applicable elsewhere as well).

## Usage

Comments wrapped inside `<!--~` and `~-->` are treated as hints and will apply to the element that follows them. For example:

```html
<!--~ This hint applies to everything between <div> and </div> ~-->
<div>
  <p>Hello.</p>
  <p>Also, hi.</p>
</div>
<p>This part is not clickable</p>
<!--~ This hint applies to the <br> tag ~-->
<br>
<p>This part is not clickable</p>
```

## Mechanics

Since [highlight.js](https://highlightjs.org/) has no native support for this, the mechanism used to achieve is the following:

1.  Treat comments inside `<!--~` and `~-->` as a special case, i.e. leave them in the HTML sent to highlight.js rather than processing and breaking into a new section.
2.  Store the content between `<!--~` and `~-->` in an internal state and assign the hint an ID.
3.  Replace the whole comment element with `<!--START_HINT_123-->` (where `123` is the previously assigned ID).
4.  Process the next element in the HTML  and append `<!--END_HINT-->` after its closing tag (or immediately after if it's a tag that doesn't close, like `<input>`.
5.  After calling the `highlight` function from highlight.js, process the output and use the generated `<span class="hljs-comment">` tags as hooks to replace with the HTML for displaying the hint.

## Other changes

Logic for the [endOfCurrentTag](https://github.com/ampproject/amp-by-example/blob/8d936229796a5bffdd526d4f1ea9414b1e2bd285/lib/DocumentParser.js#L184) method inside `DocumentParser.js` had to be amended to take into account [void elements](http://w3c.github.io/html/syntax.html#void-elements) and treat them as ending themselves, i.e. `<base href="/">` is treated as if the line is `<base href="/"></base>`. This is to allow applying hints to these tags (most notably `<input>`).

## Future improvements

-   It's currently impossible to have finer granulation than tag-level, e.g. a hint can't be applied to a single attribute.
-   The content inside the hint should be treated as markdown rather than HTML.
-   Copying code with a hint currently omits the hint. Ideally, it should include the hint as a comment.