### PR TITLE
Use fully qualified Urls for `amp-consent`

### DIFF
--- a/src/70_User_Consent/_Basic_User_Consent_Flow.html
+++ b/src/70_User_Consent/_Basic_User_Consent_Flow.html
@@ -80,7 +80,7 @@
     <script type="application/json">{
       "consents": {
             "consent1": {
-              "checkConsentHref": "/samples_templates/consent/getConsent",
+              "checkConsentHref": "https://ampbyexample.com/samples_templates/consent/getConsent",
               "promptUI": "consentDialog"
             }
           },


### PR DESCRIPTION
Currently https://ampbyexample.com/user_consent/basic_user_consent_flow/ does not work on Viewer since it fails to fetch "checkConsentHref": "/samples_templates/consent/getConsent" when served from Cache since it tries to fetch /samples_templates/consent/getConsent from CDN rather than origin.

Until https://github.com/ampproject/amphtml/issues/16683 is fixed, we should use full Urls.