### PR TITLE
Use fully qualified Urls for `amp-consent` x 2

### DIFF
--- a/src/70_User_Consent/Advanced_User_Consent_Flow.html
+++ b/src/70_User_Consent/Advanced_User_Consent_Flow.html
@@ -91,7 +91,7 @@
         <script type="application/json">{
           "consents": {
             "consent1": {
-              "checkConsentHref": "/samples_templates/consent/getConsent",
+              "checkConsentHref": "https://ampbyexample.com/samples_templates/consent/getConsent",
               "promptUI": "consentDialog"
             }
           },


### PR DESCRIPTION
same as #1347 for a different file (sorry using GitHub UI and could not do a single PR)