### PR TITLE
Refactoring use of JSON and CORS utility methods

### DIFF
--- a/backend/.vscode/settings.json
+++ b/backend/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "standard.enable": false
-}

--- a/backend/.vscode/settings.json
+++ b/backend/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "standard.enable": false
+}

--- a/backend/amp-access.go
+++ b/backend/amp-access.go
@@ -41,11 +41,11 @@ const (
 )
 
 func InitAmpAccess() {
-	http.HandleFunc(AMP_ACCESS_SAMPLE_PATH+"authorization", EnableCors(handleAuthorization))
-	http.HandleFunc(AMP_ACCESS_SAMPLE_PATH+"login", EnableCors(handleLogin))
-	http.HandleFunc(AMP_ACCESS_SAMPLE_PATH+"logout", EnableCors(handleLogout))
-	http.HandleFunc(AMP_ACCESS_SAMPLE_PATH+"pingback", EnableCors(handlePingback))
-	http.HandleFunc(AMP_ACCESS_SAMPLE_PATH+"submit", EnableCors(handleSubmit))
+	RegisterHandler(AMP_ACCESS_SAMPLE_PATH+"authorization", handleAuthorization)
+	RegisterHandler(AMP_ACCESS_SAMPLE_PATH+"login", handleLogin)
+	RegisterHandler(AMP_ACCESS_SAMPLE_PATH+"logout", handleLogout)
+	RegisterHandler(AMP_ACCESS_SAMPLE_PATH+"pingback", handlePingback)
+	RegisterHandler(AMP_ACCESS_SAMPLE_PATH+"submit", handleSubmit)
 }
 
 func handlePingback(w http.ResponseWriter, r *http.Request) {

--- a/backend/amp-access.go
+++ b/backend/amp-access.go
@@ -42,32 +42,17 @@ const (
 )
 
 func InitAmpAccess() {
-	http.HandleFunc(AMP_ACCESS_SAMPLE_PATH+"authorization", handleDefaultAuthorization)
-	http.HandleFunc(AMP_ACCESS_SAMPLE_PATH+"login", handleLogin)
-	http.HandleFunc(AMP_ACCESS_SAMPLE_PATH+"logout", handleLogout)
-	http.HandleFunc(AMP_ACCESS_SAMPLE_PATH+"pingback", handlePingback)
-	http.HandleFunc(AMP_ACCESS_SAMPLE_PATH+"submit", handleSubmit)
-}
-
-func handleAuthorization(w http.ResponseWriter, r *http.Request, authData interface{}) {
-	js, err := json.Marshal(authData)
-
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	EnableCors(w, r)
-	SetContentTypeJson(w)
-	w.Write(js)
+	http.HandleFunc(AMP_ACCESS_SAMPLE_PATH+"authorization", EnableCors(handleAuthorization))
+	http.HandleFunc(AMP_ACCESS_SAMPLE_PATH+"login", EnableCors(handleLogin))
+	http.HandleFunc(AMP_ACCESS_SAMPLE_PATH+"logout", EnableCors(handleLogout))
+	http.HandleFunc(AMP_ACCESS_SAMPLE_PATH+"pingback", EnableCors(handlePingback))
+	http.HandleFunc(AMP_ACCESS_SAMPLE_PATH+"submit", EnableCors(handleSubmit))
 }
 
 func handlePingback(w http.ResponseWriter, r *http.Request) {
-	EnableCors(w, r)
 }
 
 func handleLogin(w http.ResponseWriter, r *http.Request) {
-	EnableCors(w, r)
 	returnURL := r.URL.Query().Get("return")
 	if !isValidURL(returnURL) {
 		http.Error(w, "Invalid return URL", http.StatusInternalServerError)
@@ -78,17 +63,17 @@ func handleLogin(w http.ResponseWriter, r *http.Request) {
 	t.Execute(w, AccessData{ReturnURL: returnURL})
 }
 
-func handleDefaultAuthorization(w http.ResponseWriter, r *http.Request) {
+func handleAuthorization(w http.ResponseWriter, r *http.Request) {
 	_, err := r.Cookie(AMP_ACCESS_COOKIE)
 	if err != nil {
-		handleAuthorization(w, r, &AuthResponse{
+		SendJsonResponse(w, &AuthResponse{
 			Access:     false,
 			Subscriber: false,
 			Name:       "",
 		})
 		return
 	}
-	handleAuthorization(w, r, &AuthResponse{
+	SendJsonResponse(w, &AuthResponse{
 		Access:     true,
 		Subscriber: true,
 		Name:       "Charlie",
@@ -96,7 +81,6 @@ func handleDefaultAuthorization(w http.ResponseWriter, r *http.Request) {
 }
 
 func handleLogout(w http.ResponseWriter, r *http.Request) {
-	EnableCors(w, r)
 	//delete the cookie
 	cookie := &http.Cookie{
 		Name:   AMP_ACCESS_COOKIE,
@@ -112,7 +96,6 @@ func handleLogout(w http.ResponseWriter, r *http.Request) {
 }
 
 func handleLogoutButton(w http.ResponseWriter, r *http.Request) {
-	EnableCors(w, r)
 	returnURL := r.URL.Query().Get("return")
 	if !isValidURL(returnURL) {
 		http.Error(w, "Invalid return URL", http.StatusInternalServerError)
@@ -124,7 +107,6 @@ func handleLogoutButton(w http.ResponseWriter, r *http.Request) {
 }
 
 func handleSubmit(w http.ResponseWriter, r *http.Request) {
-	EnableCors(w, r)
 	expireInOneDay := time.Now().AddDate(0, 0, 1)
 	cookie := &http.Cookie{
 		Name:    AMP_ACCESS_COOKIE,

--- a/backend/amp-access.go
+++ b/backend/amp-access.go
@@ -13,7 +13,6 @@
 package backend
 
 import (
-	"encoding/json"
 	"fmt"
 	"html/template"
 	"net/http"

--- a/backend/amp-consent.go
+++ b/backend/amp-consent.go
@@ -23,13 +23,11 @@ const (
 )
 
 func InitAmpConsent() {
-	http.HandleFunc(CONSENT_SAMPLE_PATH+"getConsent", func(w http.ResponseWriter, r *http.Request) {
-		handlePost(w, r, submitConsentXHR)
-	})
+	http.HandleFunc(CONSENT_SAMPLE_PATH+"getConsent", onlyPost(EnableCors(submitConsentXHR)))
 }
 
 func submitConsentXHR(w http.ResponseWriter, r *http.Request) {
-	EnableCors(w, r)
-	SetContentTypeJson(w)
-	w.Write([]byte("{\"promptIfUnknown\": true}"))
+	SendJsonResponse(w, map[string]bool{
+		"promptIfUnknown": true,
+	})
 }

--- a/backend/amp-consent.go
+++ b/backend/amp-consent.go
@@ -23,7 +23,7 @@ const (
 )
 
 func InitAmpConsent() {
-	http.HandleFunc(CONSENT_SAMPLE_PATH+"getConsent", onlyPost(EnableCors(submitConsentXHR)))
+	RegisterHandler(CONSENT_SAMPLE_PATH+"getConsent", onlyPost(submitConsentXHR))
 }
 
 func submitConsentXHR(w http.ResponseWriter, r *http.Request) {

--- a/backend/amp-form.go
+++ b/backend/amp-form.go
@@ -25,10 +25,10 @@ const (
 )
 
 func InitAmpForm() {
-	http.HandleFunc(SAMPLE_NAME+"submit-form-input-text-xhr", onlyPost(EnableCors(submitFormXHRInputText)))
-	http.HandleFunc(SAMPLE_NAME+"verify-form-input-text-xhr", onlyPost(EnableCors(verifyFormXHRInputText)))
-	http.HandleFunc(SAMPLE_NAME+"submit-form-xhr", onlyPost(EnableCors(submitFormXHR)))
-	http.HandleFunc(SAMPLE_NAME+"submit-form", submitForm)
+	RegisterHandler(SAMPLE_NAME+"submit-form-input-text-xhr", onlyPost(submitFormXHRInputText))
+	RegisterHandler(SAMPLE_NAME+"verify-form-input-text-xhr", onlyPost(verifyFormXHRInputText))
+	RegisterHandler(SAMPLE_NAME+"submit-form-xhr", onlyPost(submitFormXHR))
+	RegisterHandler(SAMPLE_NAME+"submit-form", submitForm)
 }
 
 func submitFormXHRInputText(w http.ResponseWriter, r *http.Request) {

--- a/backend/amp-form.go
+++ b/backend/amp-form.go
@@ -25,56 +25,51 @@ const (
 )
 
 func InitAmpForm() {
-	http.HandleFunc(SAMPLE_NAME+"submit-form-input-text-xhr", func(w http.ResponseWriter, r *http.Request) {
-		handlePost(w, r, submitFormXHRInputText)
-	})
-	http.HandleFunc(SAMPLE_NAME+"verify-form-input-text-xhr", func(w http.ResponseWriter, r *http.Request) {
-		handlePost(w, r, verifyFormXHRInputText)
-	})
-	http.HandleFunc(SAMPLE_NAME+"submit-form-xhr", func(w http.ResponseWriter, r *http.Request) {
-		handlePost(w, r, submitFormXHR)
-	})
-	http.HandleFunc(SAMPLE_NAME+"submit-form", func(w http.ResponseWriter, r *http.Request) {
-		submitForm(w, r)
-	})
-
+	http.HandleFunc(SAMPLE_NAME+"submit-form-input-text-xhr", onlyPost(EnableCors(submitFormXHRInputText)))
+	http.HandleFunc(SAMPLE_NAME+"verify-form-input-text-xhr", onlyPost(EnableCors(verifyFormXHRInputText)))
+	http.HandleFunc(SAMPLE_NAME+"submit-form-xhr", onlyPost(EnableCors(submitFormXHR)))
+	http.HandleFunc(SAMPLE_NAME+"submit-form", submitForm)
 }
 
 func submitFormXHRInputText(w http.ResponseWriter, r *http.Request) {
-	EnableCors(w, r)
-	SetContentTypeJson(w)
-	response := ""
+	email := r.FormValue("email")
 	name := r.FormValue("name")
 	if isUserTryingTheInputTextErrorDemo(name) {
-		w.WriteHeader(http.StatusBadRequest)
+		SendJsonError(w, http.StatusBadRequest, map[string]string{
+			"name":  name,
+			"email": email,
+		})
+		return
 	}
-	email := r.FormValue("email")
-	response = fmt.Sprintf("{\"name\":\"%s\", \"email\":\"%s\"}", name, email)
-	w.Write([]byte(response))
+
+	SendJsonResponse(w, map[string]string{
+		"name":  name,
+		"email": email,
+	})
 }
 
 func verifyFormXHRInputText(w http.ResponseWriter, r *http.Request) {
-	EnableCors(w, r)
-	SetContentTypeJson(w)
-	response := ""
 	name := r.FormValue("username")
 	if isUserTryingTheInputTextErrorDemo(name) {
-		w.WriteHeader(http.StatusBadRequest)
-		response = fmt.Sprintf("{\"verifyErrors\": [{ "+
-			"\"name\": \"username\", "+
-			"\"message\":\"The username \\\"%s\\\" is already taken\""+
-			"}]}", name)
-	} else {
-		response = fmt.Sprintf("{\"username\":\"%s\"}", name)
+		SendJsonError(w, http.StatusBadRequest, map[string]interface{}{
+			"verifyErrors": []interface{}{
+				map[string]string{
+					"name":    "username",
+					"message": fmt.Sprintf("The username %q is already taken", name),
+				},
+			},
+		})
+		return
 	}
-	w.Write([]byte(response))
+	SendJsonResponse(w, map[string]string{
+		"username": name,
+	})
 }
 
 func submitFormXHR(w http.ResponseWriter, r *http.Request) {
-	EnableCors(w, r)
-	SetContentTypeJson(w)
-	response := "{\"result\":\"ok\"}"
-	w.Write([]byte(response))
+	SendJsonResponse(w, map[string]string{
+		"result": "ok",
+	})
 }
 
 func submitForm(w http.ResponseWriter, r *http.Request) {

--- a/backend/amp-story-auto-ads.go
+++ b/backend/amp-story-auto-ads.go
@@ -16,7 +16,6 @@ package backend
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"path"

--- a/backend/amp-story-auto-ads.go
+++ b/backend/amp-story-auto-ads.go
@@ -25,7 +25,7 @@ import (
 const NUMBER_OF_CONFIGS = 5
 
 func InitAmpStoryAutoAds() {
-	http.HandleFunc("/json/amp-story-auto-ads/", serveRandomAdConfig)
+	http.HandleFunc("/json/amp-story-auto-ads/", EnableCors(serveRandomAdConfig))
 }
 
 func getConfigNumber() int {
@@ -37,12 +37,5 @@ func serveRandomAdConfig(w http.ResponseWriter, r *http.Request) {
 	configName := fmt.Sprintf("amp-story-auto-ads-%v.json", configNumber)
 	filePath := path.Join(DIST_FOLDER, "json", configName)
 
-	json, err := ioutil.ReadFile(filePath)
-	if err != nil {
-		panic(err)
-	}
-
-	EnableCors(w, r)
-	SetContentTypeJson(w)
-	w.Write(json)
+	SendJsonFile(w, filePath)
 }

--- a/backend/amp-story-auto-ads.go
+++ b/backend/amp-story-auto-ads.go
@@ -24,7 +24,7 @@ import (
 const NUMBER_OF_CONFIGS = 5
 
 func InitAmpStoryAutoAds() {
-	http.HandleFunc("/json/amp-story-auto-ads/", EnableCors(serveRandomAdConfig))
+	RegisterHandler("/json/amp-story-auto-ads/", serveRandomAdConfig)
 }
 
 func getConfigNumber() int {

--- a/backend/autosuggest.go
+++ b/backend/autosuggest.go
@@ -78,9 +78,7 @@ func InitAutosuggestSample() {
 		"Cheyenne, Wyoming",
 	}
 
-	http.HandleFunc(AUTOSUGGEST_SAMPLE_PATH+"search_list", func(w http.ResponseWriter, r *http.Request) {
-		EnableCors(w, r)
-		SetContentTypeJson(w)
+	http.HandleFunc(AUTOSUGGEST_SAMPLE_PATH+"search_list", EnableCors(func(w http.ResponseWriter, r *http.Request) {
 		query := r.URL.Query().Get("q")
 
 		filteredStrs := Filter(US_CAPITAL_CITIES, func(v string) bool {
@@ -89,31 +87,33 @@ func InitAutosuggestSample() {
 
 		if len(filteredStrs) > 0 {
 			results := Min(len(filteredStrs), 4)
-			joinedStrs := strings.Join(filteredStrs[:results], "\",\"")
-			response := fmt.Sprintf("{\"items\": [{\"query\": \"%s\", \"results\":[\"%s\"]}]}", query, joinedStrs)
-			w.Write([]byte(response))
+			SendAmpListItems(w, map[string]interface{}{
+				"query":   query,
+				"results": filteredStrs[:results],
+			})
 		} else {
-			response := fmt.Sprintf("{\"items\": [{\"query\": \"%s\"}]}", query)
-			w.Write([]byte(response))
+			SendAmpListItems(w, map[string]interface{}{
+				"query": query,
+			})
 		}
-	})
+	}))
 
-	http.HandleFunc(AUTOSUGGEST_SAMPLE_PATH+"address", func(w http.ResponseWriter, r *http.Request) {
-		EnableCors(w, r)
-		SetContentTypeJson(w)
-
+	http.HandleFunc(AUTOSUGGEST_SAMPLE_PATH+"address", EnableCors(func(w http.ResponseWriter, r *http.Request) {
 		city := r.FormValue("city")
 
 		for i := range US_CAPITAL_CITIES {
 			if US_CAPITAL_CITIES[i] == city {
-				w.Write([]byte(fmt.Sprintf("{\"result\": \"Success! Your package is on it's way to %s.\"}", city)))
+				SendAmpListItems(w, map[string]interface{}{
+					"result": fmt.Sprintf("Success! Your package is on it's way to %s.", city),
+				})
 				return
 			}
 		}
 
-		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte(fmt.Sprintf("{\"result\": \"Sorry! We don't ship to %s.\"}", city)))
-	})
+		SendJsonError(w, http.StatusBadRequest, map[string]interface{}{
+			"result": fmt.Sprintf("Sorry! We don't ship to %s.", city),
+		})
+	}))
 }
 
 func Filter(vs []string, f func(string) bool) []string {

--- a/backend/autosuggest.go
+++ b/backend/autosuggest.go
@@ -78,7 +78,7 @@ func InitAutosuggestSample() {
 		"Cheyenne, Wyoming",
 	}
 
-	http.HandleFunc(AUTOSUGGEST_SAMPLE_PATH+"search_list", EnableCors(func(w http.ResponseWriter, r *http.Request) {
+	RegisterHandler(AUTOSUGGEST_SAMPLE_PATH+"search_list", func(w http.ResponseWriter, r *http.Request) {
 		query := r.URL.Query().Get("q")
 
 		filteredStrs := Filter(US_CAPITAL_CITIES, func(v string) bool {
@@ -96,9 +96,9 @@ func InitAutosuggestSample() {
 				"query": query,
 			})
 		}
-	}))
+	})
 
-	http.HandleFunc(AUTOSUGGEST_SAMPLE_PATH+"address", EnableCors(func(w http.ResponseWriter, r *http.Request) {
+	RegisterHandler(AUTOSUGGEST_SAMPLE_PATH+"address", func(w http.ResponseWriter, r *http.Request) {
 		city := r.FormValue("city")
 
 		for i := range US_CAPITAL_CITIES {
@@ -113,7 +113,7 @@ func InitAutosuggestSample() {
 		SendJsonError(w, http.StatusBadRequest, map[string]interface{}{
 			"result": fmt.Sprintf("Sorry! We don't ship to %s.", city),
 		})
-	}))
+	})
 }
 
 func Filter(vs []string, f func(string) bool) []string {

--- a/backend/checkout.go
+++ b/backend/checkout.go
@@ -25,14 +25,12 @@ const SHOPPING_CART_TOTAL = 9.94
 var discounts map[string]float32
 
 func InitCheckout() {
-	http.HandleFunc("/checkout/shopping-cart", handleShoppingCart)
-	http.HandleFunc("/checkout/apply-code", handleApplyCode)
+	http.HandleFunc("/checkout/shopping-cart", EnableCors(handleShoppingCart))
+	http.HandleFunc("/checkout/apply-code", EnableCors(handleApplyCode))
 	discounts = make(map[string]float32)
 }
 
 func handleApplyCode(w http.ResponseWriter, r *http.Request) {
-	EnableCors(w, r)
-	SetContentTypeJson(w)
 	SetMaxAge(w, 0)
 	if r.Method == "POST" {
 		clientId := r.FormValue("clientId")
@@ -42,8 +40,6 @@ func handleApplyCode(w http.ResponseWriter, r *http.Request) {
 }
 
 func handleShoppingCart(w http.ResponseWriter, r *http.Request) {
-	EnableCors(w, r)
-	SetContentTypeJson(w)
 	SetMaxAge(w, 0)
 	if r.Method == "GET" {
 		clientId := r.URL.Query().Get("clientId")
@@ -52,7 +48,6 @@ func handleShoppingCart(w http.ResponseWriter, r *http.Request) {
 }
 
 func writeShoppingCart(w http.ResponseWriter, r *http.Request, clientId string) {
-	SetContentTypeJson(w)
 	discount := discounts[clientId]
 	total := SHOPPING_CART_TOTAL - SHOPPING_CART_TOTAL*discount
 	cart := createShoppingCart()
@@ -60,8 +55,7 @@ func writeShoppingCart(w http.ResponseWriter, r *http.Request, clientId string) 
 	if discount > 0 {
 		cart["discount"] = fmt.Sprintf("%g%%", (discount * 100))
 	}
-	jsonString, _ := json.Marshal(cart)
-	w.Write([]byte(jsonString))
+	SendJsonResponse(w, cart)
 }
 
 func createShoppingCart() map[string]interface{} {

--- a/backend/checkout.go
+++ b/backend/checkout.go
@@ -15,7 +15,6 @@
 package backend
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 )

--- a/backend/checkout.go
+++ b/backend/checkout.go
@@ -24,8 +24,8 @@ const SHOPPING_CART_TOTAL = 9.94
 var discounts map[string]float32
 
 func InitCheckout() {
-	http.HandleFunc("/checkout/shopping-cart", EnableCors(handleShoppingCart))
-	http.HandleFunc("/checkout/apply-code", EnableCors(handleApplyCode))
+	RegisterHandler("/checkout/shopping-cart", handleShoppingCart)
+	RegisterHandler("/checkout/apply-code", handleApplyCode)
 	discounts = make(map[string]float32)
 }
 

--- a/backend/comment-section.go
+++ b/backend/comment-section.go
@@ -45,19 +45,15 @@ type Comment struct {
 }
 
 func InitCommentSection() {
-	http.HandleFunc(COMMENT_SAMPLE_PATH+"submit-comment-xhr", func(w http.ResponseWriter, r *http.Request) {
-		handlePost(w, r, submitCommentXHR)
-	})
-
-	http.HandleFunc(COMMENT_SAMPLE_PATH+"authorization", handleCommentAuthorization)
-	http.HandleFunc(COMMENT_SAMPLE_PATH+"login", handleLogin)
-	http.HandleFunc(COMMENT_SAMPLE_PATH+"submit-logout", handleLogout)
-	http.HandleFunc(COMMENT_SAMPLE_PATH+"logout", handleLogoutButton)
-	http.HandleFunc(COMMENT_SAMPLE_PATH+"submit", handleSubmit)
+	http.HandleFunc(COMMENT_SAMPLE_PATH+"submit-comment-xhr", onlyPost(EnableCors(submitCommentXHR)))
+	http.HandleFunc(COMMENT_SAMPLE_PATH+"authorization", EnableCors(handleCommentAuthorization))
+	http.HandleFunc(COMMENT_SAMPLE_PATH+"login", EnableCors(handleLogin))
+	http.HandleFunc(COMMENT_SAMPLE_PATH+"submit-logout", EnableCors(handleLogout))
+	http.HandleFunc(COMMENT_SAMPLE_PATH+"logout", EnableCors(handleLogoutButton))
+	http.HandleFunc(COMMENT_SAMPLE_PATH+"submit", EnableCors(handleSubmit))
 }
 
 func submitCommentXHR(w http.ResponseWriter, r *http.Request) {
-	EnableCors(w, r)
 	response := ""
 	text := r.FormValue("text")
 	if text != "" {
@@ -78,8 +74,8 @@ func submitCommentXHR(w http.ResponseWriter, r *http.Request) {
 func handleCommentAuthorization(w http.ResponseWriter, r *http.Request) {
 	_, err := r.Cookie(AMP_ACCESS_COOKIE)
 	if err != nil {
-		handleAuthorization(w, r, new(CommentAuthorizationResponse).CreateInvalidAuthorizationResponse())
+		SendJsonResponse(w, new(CommentAuthorizationResponse).CreateInvalidAuthorizationResponse())
 		return
 	}
-	handleAuthorization(w, r, new(CommentAuthorizationResponse).CreateAuthorizationResponse())
+	SendJsonResponse(w, new(CommentAuthorizationResponse).CreateAuthorizationResponse())
 }

--- a/backend/comment-section.go
+++ b/backend/comment-section.go
@@ -45,12 +45,12 @@ type Comment struct {
 }
 
 func InitCommentSection() {
-	http.HandleFunc(COMMENT_SAMPLE_PATH+"submit-comment-xhr", onlyPost(EnableCors(submitCommentXHR)))
-	http.HandleFunc(COMMENT_SAMPLE_PATH+"authorization", EnableCors(handleCommentAuthorization))
-	http.HandleFunc(COMMENT_SAMPLE_PATH+"login", EnableCors(handleLogin))
-	http.HandleFunc(COMMENT_SAMPLE_PATH+"submit-logout", EnableCors(handleLogout))
-	http.HandleFunc(COMMENT_SAMPLE_PATH+"logout", EnableCors(handleLogoutButton))
-	http.HandleFunc(COMMENT_SAMPLE_PATH+"submit", EnableCors(handleSubmit))
+	RegisterHandler(COMMENT_SAMPLE_PATH+"submit-comment-xhr", onlyPost(submitCommentXHR))
+	RegisterHandler(COMMENT_SAMPLE_PATH+"authorization", handleCommentAuthorization)
+	RegisterHandler(COMMENT_SAMPLE_PATH+"login", handleLogin)
+	RegisterHandler(COMMENT_SAMPLE_PATH+"submit-logout", handleLogout)
+	RegisterHandler(COMMENT_SAMPLE_PATH+"logout", handleLogoutButton)
+	RegisterHandler(COMMENT_SAMPLE_PATH+"submit", handleSubmit)
 }
 
 func submitCommentXHR(w http.ResponseWriter, r *http.Request) {

--- a/backend/favorite.go
+++ b/backend/favorite.go
@@ -27,13 +27,11 @@ const (
 )
 
 func InitFavoriteSample() {
-	http.HandleFunc("/favorite", handleFavorite)
-	http.HandleFunc("/favorite-with-count", handleFavoriteWithCount)
+	http.HandleFunc("/favorite", EnableCors(handleFavorite))
+	http.HandleFunc("/favorite-with-count", EnableCors(handleFavoriteWithCount))
 }
 
 func handleFavorite(w http.ResponseWriter, r *http.Request) {
-	EnableCors(w, r)
-	SetContentTypeJson(w)
 	SetMaxAge(w, 0)
 	if r.Method == "POST" {
 		setFavorite(w, r)
@@ -44,18 +42,16 @@ func handleFavorite(w http.ResponseWriter, r *http.Request) {
 
 func getFavorite(w http.ResponseWriter, r *http.Request) {
 	favorite := readFavoriteFromCookie(r, AMP_FAVORITE_COOKIE)
-	writeFavorite(w, favorite)
+	SendJsonResponse(w, favorite)
 }
 
 func setFavorite(w http.ResponseWriter, r *http.Request) {
 	favorite := !readFavoriteFromCookie(r, AMP_FAVORITE_COOKIE)
 	writeFavoriteCookie(w, r, AMP_FAVORITE_COOKIE, favorite)
-	writeFavorite(w, favorite)
+	SendJsonResponse(w, favorite)
 }
 
 func handleFavoriteWithCount(w http.ResponseWriter, r *http.Request) {
-	EnableCors(w, r)
-	SetContentTypeJson(w)
 	SetMaxAge(w, 0)
 	if r.Method == "POST" {
 		setFavoriteWithCount(w, r)
@@ -82,13 +78,10 @@ func writeFavoriteWithCount(w http.ResponseWriter, favorite bool) {
 	} else {
 		count = 123
 	}
-	response := fmt.Sprintf("{ \"value\": %t, \"count\": %d}", favorite, count)
-	w.Write([]byte(response))
-}
-
-func writeFavorite(w http.ResponseWriter, favorite bool) {
-	response := fmt.Sprintf("%t", favorite)
-	w.Write([]byte(response))
+	SendJsonResponse(w, map[string]interface{}{
+		"value": favorite,
+		"count": count,
+	})
 }
 
 func writeFavoriteCookie(w http.ResponseWriter, r *http.Request, name string, value bool) {

--- a/backend/favorite.go
+++ b/backend/favorite.go
@@ -26,8 +26,8 @@ const (
 )
 
 func InitFavoriteSample() {
-	http.HandleFunc("/favorite", EnableCors(handleFavorite))
-	http.HandleFunc("/favorite-with-count", EnableCors(handleFavoriteWithCount))
+	RegisterHandler("/favorite", handleFavorite)
+	RegisterHandler("/favorite-with-count", handleFavoriteWithCount)
 }
 
 func handleFavorite(w http.ResponseWriter, r *http.Request) {

--- a/backend/favorite.go
+++ b/backend/favorite.go
@@ -15,7 +15,6 @@
 package backend
 
 import (
-	"fmt"
 	"net/http"
 	"strconv"
 	"time"

--- a/backend/hotel.go
+++ b/backend/hotel.go
@@ -29,13 +29,11 @@ const (
 )
 
 func InitHotelSample() {
-	http.HandleFunc(HOTEL_SAMPLE_PATH+"authorization", handleHotelAuthorization)
-	http.HandleFunc(HOTEL_SAMPLE_PATH+"pingback", handlePingback)
-	http.HandleFunc(HOTEL_SAMPLE_PATH+"login", handleLogin)
-	http.HandleFunc(HOTEL_SAMPLE_PATH+"book", func(w http.ResponseWriter, r *http.Request) {
-		handlePost(w, r, book)
-	})
-	http.HandleFunc(HOTEL_SAMPLE_PATH+"check-available", checkAvailability)
+	http.HandleFunc(HOTEL_SAMPLE_PATH+"authorization", EnableCors(handleHotelAuthorization))
+	http.HandleFunc(HOTEL_SAMPLE_PATH+"pingback", EnableCors(handlePingback))
+	http.HandleFunc(HOTEL_SAMPLE_PATH+"login", EnableCors(handleLogin))
+	http.HandleFunc(HOTEL_SAMPLE_PATH+"book", onlyPost(EnableCors(book)))
+	http.HandleFunc(HOTEL_SAMPLE_PATH+"check-available", EnableCors(checkAvailability))
 }
 
 func (h HotelAuthorizationResponse) CreateAuthorizationResponse() AuthorizationResponse {
@@ -43,19 +41,17 @@ func (h HotelAuthorizationResponse) CreateAuthorizationResponse() AuthorizationR
 }
 
 func handleHotelAuthorization(w http.ResponseWriter, r *http.Request) {
-	handleAuthorization(w, r, new(HotelAuthorizationResponse).CreateAuthorizationResponse())
+	SendJsonResponse(w, new(HotelAuthorizationResponse).CreateAuthorizationResponse())
 }
 
 func checkAvailability(w http.ResponseWriter, r *http.Request) {
-	EnableCors(w, r)
-	SetContentTypeJson(w)
-	response := "{\"result\":\"Available\"}"
-	w.Write([]byte(response))
+	SendJsonResponse(w, map[string]string{
+		"result": "Available",
+	})
 }
 
 func book(w http.ResponseWriter, r *http.Request) {
-	EnableCors(w, r)
-	SetContentTypeJson(w)
-	response := "{\"result\":\"OK\"}"
-	w.Write([]byte(response))
+	SendJsonResponse(w, map[string]string{
+		"result": "OK",
+	})
 }

--- a/backend/hotel.go
+++ b/backend/hotel.go
@@ -29,11 +29,11 @@ const (
 )
 
 func InitHotelSample() {
-	http.HandleFunc(HOTEL_SAMPLE_PATH+"authorization", EnableCors(handleHotelAuthorization))
-	http.HandleFunc(HOTEL_SAMPLE_PATH+"pingback", EnableCors(handlePingback))
-	http.HandleFunc(HOTEL_SAMPLE_PATH+"login", EnableCors(handleLogin))
-	http.HandleFunc(HOTEL_SAMPLE_PATH+"book", onlyPost(EnableCors(book)))
-	http.HandleFunc(HOTEL_SAMPLE_PATH+"check-available", EnableCors(checkAvailability))
+	RegisterHandler(HOTEL_SAMPLE_PATH+"authorization", handleHotelAuthorization)
+	RegisterHandler(HOTEL_SAMPLE_PATH+"pingback", handlePingback)
+	RegisterHandler(HOTEL_SAMPLE_PATH+"login", handleLogin)
+	RegisterHandler(HOTEL_SAMPLE_PATH+"book", onlyPost(book))
+	RegisterHandler(HOTEL_SAMPLE_PATH+"check-available", checkAvailability)
 }
 
 func (h HotelAuthorizationResponse) CreateAuthorizationResponse() AuthorizationResponse {

--- a/backend/housing.go
+++ b/backend/housing.go
@@ -60,7 +60,6 @@ func parseForm(r *http.Request) (MortgageForm, error) {
 }
 
 func calculateMortgageXHR(w http.ResponseWriter, r *http.Request) {
-	response := ""
 	mortgageForm, err := parseForm(r)
 	if err != nil {
 		SendJsonError(w, http.StatusBadRequest, map[string]string{

--- a/backend/housing.go
+++ b/backend/housing.go
@@ -34,7 +34,7 @@ type MortgageForm struct {
 }
 
 func InitHousingForm() {
-	http.HandleFunc(HOUSING_SAMPLE_PATH+"calculate-mortgage-xhr", calculateMortgageXHR)
+	http.HandleFunc(HOUSING_SAMPLE_PATH+"calculate-mortgage-xhr", EnableCors(calculateMortgageXHR))
 	http.HandleFunc(HOUSING_SAMPLE_PATH+"calculate-mortgage", calculateMortgage)
 }
 
@@ -60,18 +60,18 @@ func parseForm(r *http.Request) (MortgageForm, error) {
 }
 
 func calculateMortgageXHR(w http.ResponseWriter, r *http.Request) {
-	EnableCors(w, r)
-	SetContentTypeJson(w)
 	response := ""
 	mortgageForm, err := parseForm(r)
 	if err != nil {
-		w.WriteHeader(http.StatusBadRequest)
-		response = fmt.Sprintf("{\"err\":\"%s\"}", err)
-		w.Write([]byte(response))
+		SendJsonError(w, http.StatusBadRequest, map[string]string{
+			"err": err.Error(),
+		})
+		return
 	}
 	monthlyPayment := calculateMonthlyPayment(mortgageForm)
-	response = fmt.Sprintf("{\"monthly_repayment\":\"£%.2f\"}", monthlyPayment)
-	w.Write([]byte(response))
+	SendJsonResponse(w, map[string]string{
+		"monthly_repayment": fmt.Sprintf("£%.2f", monthlyPayment),
+	})
 }
 
 func calculateMortgage(w http.ResponseWriter, r *http.Request) {

--- a/backend/housing.go
+++ b/backend/housing.go
@@ -34,8 +34,8 @@ type MortgageForm struct {
 }
 
 func InitHousingForm() {
-	http.HandleFunc(HOUSING_SAMPLE_PATH+"calculate-mortgage-xhr", EnableCors(calculateMortgageXHR))
-	http.HandleFunc(HOUSING_SAMPLE_PATH+"calculate-mortgage", calculateMortgage)
+	RegisterHandler(HOUSING_SAMPLE_PATH+"calculate-mortgage-xhr", calculateMortgageXHR)
+	RegisterHandler(HOUSING_SAMPLE_PATH+"calculate-mortgage", calculateMortgage)
 }
 
 func calculateMonthlyPayment(mortgageForm MortgageForm) float64 {

--- a/backend/paged-list.go
+++ b/backend/paged-list.go
@@ -75,7 +75,7 @@ func GeneratePagedResponse(page int) AmpListResponse {
 }
 
 func InitPagedListSample() {
-	http.HandleFunc(PAGED_LIST_SAMPLE_PATH+"search", EnableCors(func(w http.ResponseWriter, r *http.Request) {
+	RegisterHandler(PAGED_LIST_SAMPLE_PATH+"search", func(w http.ResponseWriter, r *http.Request) {
 		pageString := r.URL.Query().Get("page")
 		if pageString == "" {
 			pageString = "1"
@@ -90,5 +90,5 @@ func InitPagedListSample() {
 				"error": "Invalid page",
 			})
 		}
-	}))
+	})
 }

--- a/backend/paged-list.go
+++ b/backend/paged-list.go
@@ -15,7 +15,6 @@
 package backend
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"strconv"

--- a/backend/paged-list.go
+++ b/backend/paged-list.go
@@ -76,10 +76,7 @@ func GeneratePagedResponse(page int) AmpListResponse {
 }
 
 func InitPagedListSample() {
-	http.HandleFunc(PAGED_LIST_SAMPLE_PATH+"search", func(w http.ResponseWriter, r *http.Request) {
-		EnableCors(w, r)
-		SetContentTypeJson(w)
-
+	http.HandleFunc(PAGED_LIST_SAMPLE_PATH+"search", EnableCors(func(w http.ResponseWriter, r *http.Request) {
 		pageString := r.URL.Query().Get("page")
 		if pageString == "" {
 			pageString = "1"
@@ -88,10 +85,11 @@ func InitPagedListSample() {
 
 		if page <= MAX_PAGE_COUNT && page > 0 {
 			response := GeneratePagedResponse(page)
-			jsonBytes, _ := json.Marshal(&response)
-			w.Write([]byte(jsonBytes))
+			SendJsonResponse(w, &response)
 		} else {
-			w.Write([]byte("{\"error\": \"Invalid page\"}"))
+			SendJsonResponse(w, map[string]string{
+				"error": "Invalid page",
+			})
 		}
-	})
+	}))
 }

--- a/backend/poll.go
+++ b/backend/poll.go
@@ -81,7 +81,7 @@ var pollQuestions PollQuestions
 func InitPollSample() {
 	questions = []string{"Penguins", "Ostriches", "Kiwis", "Wekas"}
 	pollQuestions = PollQuestions{questions}
-	http.HandleFunc(POLL_SAMPLE_PATH+"submit", submitPoll)
+	http.HandleFunc(POLL_SAMPLE_PATH+"submit", EnableCors(submitPoll))
 	RegisterSample(CATEGORY_SAMPLE_TEMPLATES+"/poll", handlePoll)
 }
 
@@ -105,8 +105,6 @@ func createPollResult(answers []int, message string) PollResult {
 }
 
 func submitPoll(w http.ResponseWriter, r *http.Request) {
-	EnableCors(w, r)
-	SetContentTypeJson(w)
 	context := appengine.NewContext(r)
 	pollForm, error := parsePollForm(w, r, context)
 	if error != nil {
@@ -118,7 +116,7 @@ func submitPoll(w http.ResponseWriter, r *http.Request) {
 		handleError(error, w)
 		return
 	}
-	json.NewEncoder(w).Encode(pollResult)
+	SendJsonResponse(w, pollResult)
 }
 
 func parsePollForm(w http.ResponseWriter, r *http.Request, context context.Context) (PollForm, error) {

--- a/backend/poll.go
+++ b/backend/poll.go
@@ -15,7 +15,6 @@
 package backend
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"golang.org/x/net/context"

--- a/backend/poll.go
+++ b/backend/poll.go
@@ -80,7 +80,7 @@ var pollQuestions PollQuestions
 func InitPollSample() {
 	questions = []string{"Penguins", "Ostriches", "Kiwis", "Wekas"}
 	pollQuestions = PollQuestions{questions}
-	http.HandleFunc(POLL_SAMPLE_PATH+"submit", EnableCors(submitPoll))
+	RegisterHandler(POLL_SAMPLE_PATH+"submit", submitPoll)
 	RegisterSample(CATEGORY_SAMPLE_TEMPLATES+"/poll", handlePoll)
 }
 

--- a/backend/product-browse.go
+++ b/backend/product-browse.go
@@ -86,16 +86,13 @@ func InitProductBrowse() {
 	RegisterSample("samples_templates/product_page", renderProduct)
 	RegisterSampleEndpoint("samples_templates/product_browse_page", SEARCH, handleSearchRequest)
 	http.HandleFunc("/samples_templates/products", handleProductsRequest)
-	http.HandleFunc("/samples_templates/products_autosuggest", handleProductsAutosuggestRequest)
-	http.HandleFunc(SHOW_MORE_PATH, handleLoadMoreRequest)
-	http.HandleFunc(ADD_TO_CART_PATH, func(w http.ResponseWriter, r *http.Request) {
-		handlePost(w, r, addToCart)
-	})
+	http.HandleFunc("/samples_templates/products_autosuggest", EnableCors(handleProductsAutosuggestRequest))
+	http.HandleFunc(SHOW_MORE_PATH, EnableCors(handleLoadMoreRequest))
+	http.HandleFunc(ADD_TO_CART_PATH, onlyPost(EnableCors(addToCart)))
 	cache = NewLRUCache(100)
 }
 
 func addToCart(w http.ResponseWriter, r *http.Request) {
-	EnableCors(w, r)
 	clientId := r.FormValue("clientId")
 	if clientId == "" {
 		w.WriteHeader(http.StatusBadRequest)
@@ -259,8 +256,6 @@ func handleSearchRequest(w http.ResponseWriter, r *http.Request, page Page) {
 }
 
 func handleLoadMoreRequest(w http.ResponseWriter, r *http.Request) {
-	EnableCors(w, r)
-	SetContentTypeJson(w)
 	moreItemsPageIndex := r.URL.Query().Get("moreItemsPageIndex")
 	productsFile, err := ioutil.ReadFile(buildShowMorePath(moreItemsPageIndex))
 	if err != nil {
@@ -277,9 +272,7 @@ func handleLoadMoreRequest(w http.ResponseWriter, r *http.Request) {
 		productsRoot.HasMorePages = true
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	productsFile, err = json.Marshal(productsRoot)
-	w.Write(productsFile)
+	SendJsonResponse(w, productsRoot)
 }
 
 func buildShowMorePath(moreItemsPageIndex string) string {
@@ -326,8 +319,6 @@ func handleProductsRequest(w http.ResponseWriter, r *http.Request) {
 }
 
 func handleProductsAutosuggestRequest(w http.ResponseWriter, r *http.Request) {
-	EnableCors(w, r)
-	SetContentTypeJson(w)
 	query := r.URL.Query().Get("search")
 
 	var productDescs []string
@@ -341,12 +332,14 @@ func handleProductsAutosuggestRequest(w http.ResponseWriter, r *http.Request) {
 
 	if len(filteredStrs) > 0 {
 		results := Min(len(filteredStrs), 4)
-		joinedStrs := strings.Join(filteredStrs[:results], "\",\"")
-		response := fmt.Sprintf("{\"items\": [{\"query\": \"%s\", \"results\":[\"%s\"]}]}", query, joinedStrs)
-		w.Write([]byte(response))
+		SendAmpListItems(w, map[string]interface{}{
+			"query":   query,
+			"results": filteredStrs[:results],
+		})
 	} else {
-		response := fmt.Sprintf("{\"items\": [{\"query\": \"%s\"}]}", query)
-		w.Write([]byte(response))
+		SendAmpListItems(w, map[string]interface{}{
+			"query": query,
+		})
 	}
 }
 

--- a/backend/product-browse.go
+++ b/backend/product-browse.go
@@ -85,10 +85,10 @@ func InitProductBrowse() {
 	RegisterSample("samples_templates/product_browse_page", renderProductBrowsePage)
 	RegisterSample("samples_templates/product_page", renderProduct)
 	RegisterSampleEndpoint("samples_templates/product_browse_page", SEARCH, handleSearchRequest)
-	http.HandleFunc("/samples_templates/products", handleProductsRequest)
-	http.HandleFunc("/samples_templates/products_autosuggest", EnableCors(handleProductsAutosuggestRequest))
-	http.HandleFunc(SHOW_MORE_PATH, EnableCors(handleLoadMoreRequest))
-	http.HandleFunc(ADD_TO_CART_PATH, onlyPost(EnableCors(addToCart)))
+	RegisterHandler("/samples_templates/products", handleProductsRequest)
+	RegisterHandler("/samples_templates/products_autosuggest", handleProductsAutosuggestRequest)
+	RegisterHandler(SHOW_MORE_PATH, handleLoadMoreRequest)
+	RegisterHandler(ADD_TO_CART_PATH, onlyPost(addToCart))
 	cache = NewLRUCache(100)
 }
 

--- a/backend/rating.go
+++ b/backend/rating.go
@@ -15,7 +15,6 @@
 package backend
 
 import (
-	"fmt"
 	"net/http"
 )
 

--- a/backend/rating.go
+++ b/backend/rating.go
@@ -24,15 +24,12 @@ const (
 )
 
 func InitRatingSample() {
-	http.HandleFunc(RATING_SAMPLE_PATH+"set", func(w http.ResponseWriter, r *http.Request) {
-		handlePost(w, r, submitRatingXHR)
-	})
+	http.HandleFunc(RATING_SAMPLE_PATH+"set", onlyPost(EnableCors(submitRatingXHR)))
 }
 
 func submitRatingXHR(w http.ResponseWriter, r *http.Request) {
-	EnableCors(w, r)
-	SetContentTypeJson(w)
 	rating := r.FormValue("rating")
-	response := fmt.Sprintf("{\"rating\":\"%s\"}", rating)
-	w.Write([]byte(response))
+	SendJsonResponse(w, map[string]string{
+		"rating": rating,
+	})
 }

--- a/backend/rating.go
+++ b/backend/rating.go
@@ -23,7 +23,7 @@ const (
 )
 
 func InitRatingSample() {
-	http.HandleFunc(RATING_SAMPLE_PATH+"set", onlyPost(EnableCors(submitRatingXHR)))
+	RegisterHandler(RATING_SAMPLE_PATH+"set", onlyPost(submitRatingXHR))
 }
 
 func submitRatingXHR(w http.ResponseWriter, r *http.Request) {

--- a/backend/request.go
+++ b/backend/request.go
@@ -50,11 +50,10 @@ func EnableCors(next http.HandlerFunc) http.HandlerFunc {
 		w.Header().Set("Access-Control-Allow-Credentials", "true")
 
 		sourceOrigin := GetSourceOrigin(r)
-		if sourceOrigin == "" {
-			return
+		if sourceOrigin != "" {
+			w.Header().Set("Access-Control-Expose-Headers", "AMP-Access-Control-Allow-Source-Origin")
+			w.Header().Set("AMP-Access-Control-Allow-Source-Origin", sourceOrigin)
 		}
-		w.Header().Set("Access-Control-Expose-Headers", "AMP-Access-Control-Allow-Source-Origin")
-		w.Header().Set("AMP-Access-Control-Allow-Source-Origin", sourceOrigin)
 
 		next.ServeHTTP(w, r)
 	}

--- a/backend/request.go
+++ b/backend/request.go
@@ -15,7 +15,9 @@
 package backend
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"strings"
 )
@@ -39,19 +41,23 @@ func isFormPostRequest(method string, w http.ResponseWriter) bool {
 	return true
 }
 
-func EnableCors(w http.ResponseWriter, r *http.Request) {
-	origin := GetOrigin(r)
-	w.Header().Set("Access-Control-Allow-Origin", origin)
-	w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token")
-	w.Header().Set("Access-Control-Allow-Credentials", "true")
+func EnableCors(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		origin := GetOrigin(r)
+		w.Header().Set("Access-Control-Allow-Origin", origin)
+		w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token")
+		w.Header().Set("Access-Control-Allow-Credentials", "true")
 
-	sourceOrigin := GetSourceOrigin(r)
-	if sourceOrigin == "" {
-		return
+		sourceOrigin := GetSourceOrigin(r)
+		if sourceOrigin == "" {
+			return
+		}
+		w.Header().Set("Access-Control-Expose-Headers", "AMP-Access-Control-Allow-Source-Origin")
+		w.Header().Set("AMP-Access-Control-Allow-Source-Origin", sourceOrigin)
+
+		next.ServeHTTP(w, r)
 	}
-	w.Header().Set("Access-Control-Expose-Headers", "AMP-Access-Control-Allow-Source-Origin")
-	w.Header().Set("AMP-Access-Control-Allow-Source-Origin", sourceOrigin)
 }
 
 func GetOrigin(r *http.Request) string {
@@ -81,6 +87,43 @@ func SetContentTypeJson(w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "application/json")
 }
 
+func SendJsonResponse(w http.ResponseWriter, data interface{}) {
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	SetContentTypeJson(w)
+	w.Write(jsonData)
+}
+
+func SendJsonError(w http.ResponseWriter, code int, data interface{}) {
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	SetContentTypeJson(w)
+	w.WriteHeader(code)
+	w.Write(jsonData)
+}
+
+func SendAmpListItems(w http.ResponseWriter, data ...interface{}) {
+	SendJsonResponse(w, map[string]interface{}{
+		"items": data,
+	})
+}
+
+func SendJsonFile(w http.ResponseWriter, filePath string) {
+	jsonData, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	SetContentTypeJson(w)
+	w.Write(jsonData)
+}
+
 func SetDefaultMaxAge(w http.ResponseWriter) {
 	SetMaxAge(w, DEFAULT_MAX_AGE)
 }
@@ -89,10 +132,12 @@ func SetMaxAge(w http.ResponseWriter, age int) {
 	w.Header().Set("cache-control", fmt.Sprintf("max-age=%d, public, must-revalidate", age))
 }
 
-func handlePost(w http.ResponseWriter, r *http.Request, postHandler func(http.ResponseWriter, *http.Request)) {
-	if r.Method != "POST" {
-		http.Error(w, "post only", http.StatusMethodNotAllowed)
-		return
+func onlyPost(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			http.Error(w, "post only", http.StatusMethodNotAllowed)
+			return
+		}
+		next.ServeHTTP(w, r)
 	}
-	postHandler(w, r)
 }

--- a/backend/slow-response.go
+++ b/backend/slow-response.go
@@ -17,7 +17,6 @@ package backend
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"strconv"
 	"time"

--- a/backend/slow-response.go
+++ b/backend/slow-response.go
@@ -29,9 +29,9 @@ const (
 )
 
 func InitSlowResponseSample() {
-	http.HandleFunc(SLOW_JSON_SAMPLE_PATH+"", EnableCors(slowJson))
-	http.HandleFunc(SLOW_JSON_WITH_ITEMS_SAMPLE_PATH+"", slowJsonWithItems)
-	http.HandleFunc(SLOW_IFRAME_SAMPLE_PATH+"", slowIframe)
+	RegisterHandler(SLOW_JSON_SAMPLE_PATH+"", slowJson)
+	RegisterHandler(SLOW_JSON_WITH_ITEMS_SAMPLE_PATH+"", slowJsonWithItems)
+	RegisterHandler(SLOW_IFRAME_SAMPLE_PATH+"", slowIframe)
 }
 
 func addDelay(r *http.Request) {

--- a/backend/slow-response.go
+++ b/backend/slow-response.go
@@ -30,19 +30,9 @@ const (
 )
 
 func InitSlowResponseSample() {
-	http.HandleFunc(SLOW_JSON_SAMPLE_PATH+"", slowJson)
+	http.HandleFunc(SLOW_JSON_SAMPLE_PATH+"", EnableCors(slowJson))
 	http.HandleFunc(SLOW_JSON_WITH_ITEMS_SAMPLE_PATH+"", slowJsonWithItems)
 	http.HandleFunc(SLOW_IFRAME_SAMPLE_PATH+"", slowIframe)
-}
-
-func prepResponse(w http.ResponseWriter, r *http.Request) {
-	EnableCors(w, r)
-	SetContentTypeJson(w)
-	addDelay(r)
-}
-
-func createResponse(responseContent string, r *http.Request) string {
-	return fmt.Sprintf(responseContent, getDelay(r))
 }
 
 func addDelay(r *http.Request) {
@@ -57,29 +47,18 @@ func getDelay(r *http.Request) uint64 {
 }
 
 func slowJson(w http.ResponseWriter, r *http.Request) {
-	prepResponse(w, r)
-	responseContent := "{\"items\":[{\"title\": \"This JSON response was delayed %v milliseconds. Hard-refresh the page (Ctrl/Cmd+Shift+R) if you didn't see the spinner.\"}]}"
-	response := fmt.Sprintf(createResponse(responseContent, r))
-	w.Write([]byte(response))
+	addDelay(r)
+	SendAmpListItems(w, map[string]string{
+		"title": fmt.Sprintf("This JSON response was delayed %v milliseconds. Hard-refresh the page (Ctrl/Cmd+Shift+R) if you didn't see the spinner.", getDelay(r)),
+	})
 }
 
 func slowJsonWithItems(w http.ResponseWriter, r *http.Request) {
-	products := readProducts(DIST_FOLDER + "/json/related_products.json")
-	prepResponse(w, r)
-	w.Write([]byte(products))
-}
-
-func readProducts(path string) string {
-	productsFile, err := ioutil.ReadFile(path)
-	if err != nil {
-		panic(err)
-	}
-	return string(productsFile)
+	addDelay(r)
+	SendJsonFile(w, DIST_FOLDER+"/json/related_products.json")
 }
 
 func slowIframe(w http.ResponseWriter, r *http.Request) {
-	prepResponse(w, r)
-	responseContent := "This iframe was delayed %v milliseconds. Hard-refresh the page (Ctrl/Cmd+Shift+R) if you didn't see the spinner."
-	response := fmt.Sprintf(createResponse(responseContent, r))
-	w.Write([]byte(response))
+	addDelay(r)
+	fmt.Fprintf(w, "This iframe was delayed %v milliseconds. Hard-refresh the page (Ctrl/Cmd+Shift+R) if you didn't see the spinner.", getDelay(r))
 }

--- a/backend/template.go
+++ b/backend/template.go
@@ -59,13 +59,13 @@ func RegisterTemplate(route string, mode string, templatePath string,
 		template: parseTemplate(templatePath),
 		Route:    route,
 	}
-	http.HandleFunc(route, EnableCors(func(w http.ResponseWriter, r *http.Request) {
+	RegisterHandler(route, func(w http.ResponseWriter, r *http.Request) {
 		if IsInsecureRequest(r) {
 			RedirectToSecureVersion(w, r)
 			return
 		}
 		handler(w, r, page)
-	}))
+	})
 }
 
 func registerSampleEndpointHandler(samplePath string, mode string, endpoint string,
@@ -75,7 +75,7 @@ func registerSampleEndpointHandler(samplePath string, mode string, endpoint stri
 		Route: route,
 		Mode:  mode,
 	}
-	http.HandleFunc(route, func(w http.ResponseWriter, r *http.Request) {
+	RegisterHandler(route, func(w http.ResponseWriter, r *http.Request) {
 		handler(w, r, page)
 	})
 }

--- a/backend/template.go
+++ b/backend/template.go
@@ -59,14 +59,13 @@ func RegisterTemplate(route string, mode string, templatePath string,
 		template: parseTemplate(templatePath),
 		Route:    route,
 	}
-	http.HandleFunc(route, func(w http.ResponseWriter, r *http.Request) {
+	http.HandleFunc(route, EnableCors(func(w http.ResponseWriter, r *http.Request) {
 		if IsInsecureRequest(r) {
 			RedirectToSecureVersion(w, r)
 			return
 		}
-		EnableCors(w, r)
 		handler(w, r, page)
-	})
+	}))
 }
 
 func registerSampleEndpointHandler(samplePath string, mode string, endpoint string,

--- a/server.go
+++ b/server.go
@@ -64,12 +64,11 @@ func HandleNotFound(h http.Handler) http.HandlerFunc {
 }
 
 func ServeStaticFiles(h http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	return backend.EnableCors(func(w http.ResponseWriter, r *http.Request) {
 		if r.Host == OLD_ADDRESS || backend.IsInsecureRequest(r) {
 			backend.RedirectToSecureVersion(w, r)
 			return
 		}
-		backend.EnableCors(w, r)
 		backend.SetDefaultMaxAge(w)
 		h.ServeHTTP(w, r)
 	})


### PR DESCRIPTION
(WIP, please don't merge yet)

*   Changed `backend.EnableCors` to act as middleware.
*   Changed `handlePost` to act as middleware and renamed to `onlyPost`.
*   Added utility methods `SendJsonResponse`, `SendJsonError` and `SendAmpListItems`.
*   Removed all "hardcoded" JSON strings and replaced with maps where applicable.
