### PR TITLE
Change check on form validation to allow unicode characters too

### DIFF
--- a/src/20_Components/amp-form.html
+++ b/src/20_Components/amp-form.html
@@ -121,7 +121,7 @@
         custom-validation-reporting="show-all-on-submit">
     <p>Form Custom Validation: <code>show-all-on-submit</code></p>
     <div class="ampstart-input inline-block relative m0 p0 mb3">
-      <input type="text" class="block border-none p0 m0" id="show-all-on-submit-name" name="name" placeholder="Name..." required pattern="\w+\s\w+">
+      <input type="text" class="block border-none p0 m0" id="show-all-on-submit-name" name="name" placeholder="Name..." required pattern="\p{L}+\s\p{L}+">
       <span visible-when-invalid="valueMissing"
         validation-for="show-all-on-submit-name"></span>
       <span visible-when-invalid="patternMismatch"
@@ -155,7 +155,7 @@
         custom-validation-reporting="show-first-on-submit">
     <p>Form Custom Validation: <code>show-first-on-submit</code></p>
     <div class="ampstart-input inline-block relative m0 p0 mb3">
-      <input type="text" class="block border-none p0 m0" id="show-first-on-submit-name"  name="name" placeholder="Name..." required pattern="\w+\s\w+">
+      <input type="text" class="block border-none p0 m0" id="show-first-on-submit-name"  name="name" placeholder="Name..." required pattern="\p{L}+\s\p{L}+">
       <span visible-when-invalid="valueMissing"
         validation-for="show-first-on-submit-name"></span>
       <span visible-when-invalid="patternMismatch"
@@ -189,7 +189,7 @@
         custom-validation-reporting="as-you-go">
     <p>Form Custom Validation: <code>as-you-go</code></p>
     <div class="ampstart-input inline-block relative m0 p0 mb3">
-      <input type="text" class="block border-none p0 m0" id="as-you-go-name" name="name" placeholder="Name..." required pattern="\w+\s\w+">
+      <input type="text" class="block border-none p0 m0" id="as-you-go-name" name="name" placeholder="Name..." required pattern="\p{L}+\s\p{L}+">
       <span visible-when-invalid="valueMissing"
         validation-for="as-you-go-name"></span>
       <span visible-when-invalid="patternMismatch"


### PR DESCRIPTION
Fix found here: https://www.regular-expressions.info/unicode.html#prop

This was reported as an issue in the amphtml repo here: https://github.com/ampproject/amphtml/issues/13388