### PR TITLE
Fix stories bookend configuration.

### DIFF
--- a/tasks/bookend.json
+++ b/tasks/bookend.json
@@ -1,13 +1,14 @@
 {
   "bookendVersion": "v1.0",
-  "share-providers": {
-    "email": true,
-    "twitter": true,
-    "tumblr": true,
-    "facebook": {
+  "shareProviders": [
+    "email",
+    "twitter",
+    "tumblr",
+    {
+      "provider": "facebook",
       "app_id": "254325784911610"
     }
-  },
+  ],
   "components": [
   ]
 }


### PR DESCRIPTION
Bookend configuration was still using the `shareProviders` configuration for the `v0.1`. Upgrading to `v1.0`.

See: https://www.ampproject.org/docs/design/visual_story/create_bookend