### PR TITLE
Serve static files with normal CORS headers

### DIFF
--- a/backend/request.go
+++ b/backend/request.go
@@ -47,20 +47,18 @@ func isFormPostRequest(method string, w http.ResponseWriter) bool {
 
 func EnableCors(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		sourceOrigin := GetSourceOrigin(r)
-		if sourceOrigin == "" {
-			next.ServeHTTP(w, r)
-			return
-		}
-
 		origin := GetOrigin(r)
 		w.Header().Set("Access-Control-Allow-Origin", origin)
 		w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS")
 		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token")
 		w.Header().Set("Access-Control-Allow-Credentials", "true")
+		sourceOrigin := GetSourceOrigin(r)
+		if sourceOrigin == "" {
+			next.ServeHTTP(w, r)
+			return
+		}
 		w.Header().Set("Access-Control-Expose-Headers", "AMP-Access-Control-Allow-Source-Origin")
 		w.Header().Set("AMP-Access-Control-Allow-Source-Origin", sourceOrigin)
-
 		next.ServeHTTP(w, r)
 	}
 }


### PR DESCRIPTION
Currenlyt normal CORS headers are only set when AMP CORS headers are
required. This breaks the amp-3d-gltf sample.

The fix is to always the normal CORS headers and add AMP CORS headers if
the source origin get parameter is set.

Fixes #1437