### PR TITLE
Update the documentation around amp-bind.

### DIFF
--- a/src/20_Components/amp-bind.html
+++ b/src/20_Components/amp-bind.html
@@ -158,9 +158,30 @@
     <!-- ## Triggering updates -->
     <!--
       Data bindings are re-evaluated when implicit state changes. Implicit state can
-      be updated via the `AMP.setState` [action](https://github.com/ampproject/amphtml/blob/master/spec/amp-actions-and-events.md).
+      be updated via the `AMP.setState` action in response to an event.
+      [Read more about actions and events](https://www.ampproject.org/docs/interaction_dynamic/amp-actions-and-events).
+   
+      You can use [various events](https://www.ampproject.org/docs/interaction_dynamic/amp-actions-and-events#element-specific-events)
+      on input/form elements as well as AMP elements to trigger `AMP.setState`.
+      For a more in-depth example using multiple events, see [autosuggest](https://ampbyexample.com/advanced/autosuggest/).
+    -->
+    <div class="ampstart-input m1">
+      <input id="name-input" placeholder="Enter a name" on="input-throttled:AMP.setState({name: event.value})">
+      <div class="mt1">
+        Hello <em [text]="name"></em>!
+      </div>
+    </div>
 
-      - `AMP.setState` merges new state into existing implicit state
+    <!-- ## Setting new state -->
+    <!--
+      The `setState` action takes an object that tells it what state to update.
+      A few notes about the update object:
+      - `AMP.setState` merges the new state into the existing implicit state
+      - The top level property names correspond to the `id` of an `<amp-state>`
+          * In the following example, we are updating the state held by
+            `<amp-state id="allAnimals">`
+          * You can update state without an asociated `<amp-state>` Element, as
+            in the previous example
       - Existing state can be overwritten, including state initialized by
       `amp-state` components
     -->


### PR DESCRIPTION
- Add a link to what events you can listen to
- Describe the state object a little more explicitly

Context for this update: https://github.com/ampproject/amphtml/issues/17471. Seems that some clarity around what the events you can use with `setState` and how they differ would be useful.