### PR TITLE
Remove leftover script tag for amp-image-slider

### DIFF
--- a/src/20_Components/amp-image-slider.html
+++ b/src/20_Components/amp-image-slider.html
@@ -46,7 +46,6 @@
       transform: translateY(-50%);
     }
   </style>
-  <script custom-element="amp-image-slider" src="<%host%>/amp-image-slider-0.1.max.js"></script>
 </head>
 <body>
 


### PR DESCRIPTION
Forgot to remove a leftover script tag originated from testing (`.max.js` version). It does not break anything tho