### PR TITLE
Make all stories self-canonical

### DIFF
--- a/src/stories/10_Introduction/_AMP_Story_Hello_World.html
+++ b/src/stories/10_Introduction/_AMP_Story_Hello_World.html
@@ -16,6 +16,7 @@
     <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
     <title>Stories in AMP - Hello World</title>
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+    <!-- The canonical link reference must be self-referential. -->
     <link rel="canonical" href="/stories/introduction/amp_story_hello_world/preview/embed/">
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
     <!-- Stories can be styled using CSS: -->

--- a/src/stories/20_Features/Animations.html
+++ b/src/stories/20_Features/Animations.html
@@ -9,7 +9,7 @@
 <head>
   <meta charset="utf-8">
   <title>amp-story</title>
-  <link rel="canonical" href="/stories/features/animations/">
+  <link rel="canonical" href="/stories/features/animations/preview/embed/">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>

--- a/src/stories/20_Features/Layouts.html
+++ b/src/stories/20_Features/Layouts.html
@@ -16,7 +16,7 @@
 
     <meta name="viewport"
           content="width=device-width,minimum-scale=1,initial-scale=1">
-    <link rel="canonical" href="/stories/features/layouts/">
+    <link rel="canonical" href="/stories/features/layouts/preview/embed/">
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
     <style amp-custom>
       body {

--- a/src/stories/20_Features/Media.html
+++ b/src/stories/20_Features/Media.html
@@ -22,7 +22,7 @@
     <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
     <meta name="viewport"
           content="width=device-width,minimum-scale=1,initial-scale=1">
-    <link rel="canonical" href="/stories/features/media/">
+    <link rel="canonical" href="/stories/features/media/preview/embed/">
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
     <style amp-custom>
       body {

--- a/src/stories/30_Monetization/DoubleClick.html
+++ b/src/stories/30_Monetization/DoubleClick.html
@@ -15,7 +15,7 @@
 <html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
-  <link rel="canonical" href="https://ampbyexample.com/stories/monetization/doubleclick/">
+  <link rel="canonical" href="https://ampbyexample.com/stories/monetization/doubleclick/preview/embed/">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <title>DoubleClick Ads for AMP Stories</title>

--- a/src/stories/30_Monetization/Publisher_Served.html
+++ b/src/stories/30_Monetization/Publisher_Served.html
@@ -15,7 +15,7 @@
 <html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
-  <link rel="canonical" href="https://ampbyexample.com/stories/monetization/publisher_served/">
+  <link rel="canonical" href="https://ampbyexample.com/stories/monetization/publisher_served/preview/embed/">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <title>Publisher Served Ads for AMP Stories</title>

--- a/src/stories/30_Visual_Effects/Ken_Burns.html
+++ b/src/stories/30_Visual_Effects/Ken_Burns.html
@@ -10,7 +10,7 @@
 
 <head>
   <meta charset="utf-8">
-  <link rel="canonical" href="/stories/visual_effects/ken_burns/">
+  <link rel="canonical" href="/stories/visual_effects/ken_burns/preview/embed/">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>

--- a/src/stories/50_User_Consent/Story_User_Consent.html
+++ b/src/stories/50_User_Consent/Story_User_Consent.html
@@ -12,7 +12,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
-  <link rel="canonical" href="/stories/user_consent/story_user_consent/">
+  <link rel="canonical" href="/stories/user_consent/story_user_consent/preview/embed/">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <title>AMP Story with User Consent</title>


### PR DESCRIPTION
This is an attempt to arrange for all the AMP Story examples to have a self-referential `<link rel=canonical>` [as required](https://www.ampproject.org/docs/reference/components/amp-story#required-markup-for-amp-story).

That is, a URL such as `https://ampbyexample.com/stories/introduction/amp_story_hello_world/preview/embed/` should have a `<link rel=canonical>` of

```html
<link rel=canonical href=https://ampbyexample.com/stories/introduction/amp_story_hello_world/preview/embed/>
```