### PR TITLE
Fix <link rel=canonical>

### DIFF
--- a/src/30_Advanced/Payments_in_AMP.html
+++ b/src/30_Advanced/Payments_in_AMP.html
@@ -15,7 +15,7 @@ Via [amp-iframe](/components/amp-iframe) and the `allowpaymentrequest` attribute
 <head>
   <meta charset="utf-8">
   <title>Payments in AMP</title>
-  <link rel="canonical" href="<%host%>/advanced/payments_iframe/">
+  <link rel="canonical" href="<%host%>/advanced/payments_in_amp/">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <!-- ## Setup -->


### PR DESCRIPTION
The `<link rel=canonical>` of [Payments in AMP](https://ampbyexample.com/advanced/payments_in_amp/) (and its demo version) is https://ampbyexample.com/advanced/payments_iframe/, which 404s.