### PR TITLE
New OAuth2 flow for comment section

### DIFF
--- a/backend/amp-analytics.go
+++ b/backend/amp-analytics.go
@@ -15,6 +15,8 @@
 package backend
 
 import (
+	"backend/util"
+
 	"net/http"
 )
 
@@ -30,7 +32,7 @@ func renderAnalyticsSample(w http.ResponseWriter, r *http.Request, page Page) {
 func clientId(r *http.Request) string {
 	cookie, err := r.Cookie(AMP_CLIENT_ID_COOKIE)
 	if err != nil {
-		return RandomString(8)
+		return util.RandomString(8)
 	} else {
 		return cookie.Value
 	}

--- a/backend/cookie/cookie.go
+++ b/backend/cookie/cookie.go
@@ -1,0 +1,60 @@
+// Copyright Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cookie
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+)
+
+func Set(w http.ResponseWriter, name string, value interface{}) error {
+	dataJson, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     name,
+		Value:    base64.RawStdEncoding.EncodeToString(dataJson),
+		Path:     "/",
+		HttpOnly: true,
+	})
+	return nil
+}
+
+func Get(r *http.Request, name string, out interface{}) error {
+	cookie, err := r.Cookie(name)
+	if err != nil {
+		return err
+	}
+	data, err := base64.RawStdEncoding.DecodeString(cookie.Value)
+	if err != nil {
+		return err
+	}
+
+	if err := json.Unmarshal(data, out); err != nil {
+		return err
+	}
+	return nil
+}
+
+func Clear(w http.ResponseWriter, name string) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     name,
+		Path:     "/",
+		HttpOnly: true,
+		MaxAge:   -1,
+	})
+}

--- a/backend/datastore.go
+++ b/backend/datastore.go
@@ -1,3 +1,17 @@
+// Copyright Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package backend
 
 import (

--- a/backend/datastore.go
+++ b/backend/datastore.go
@@ -1,0 +1,37 @@
+package backend
+
+import (
+	"io/ioutil"
+
+	"cloud.google.com/go/storage"
+	"golang.org/x/net/context"
+	"google.golang.org/appengine/file"
+)
+
+func readFileFromDatastore(ctx context.Context, filename string) ([]byte, error) {
+	bucketName, err := file.DefaultBucketName(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer client.Close()
+
+	bucket := client.Bucket(bucketName)
+
+	rc, err := bucket.Object(filename).NewReader(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer rc.Close()
+
+	data, err := ioutil.ReadAll(rc)
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}

--- a/backend/datastore/datastore.go
+++ b/backend/datastore/datastore.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package backend
+package datastore
 
 import (
 	"io/ioutil"
@@ -22,7 +22,7 @@ import (
 	"google.golang.org/appengine/file"
 )
 
-func readFileFromDatastore(ctx context.Context, filename string) ([]byte, error) {
+func ReadFile(ctx context.Context, filename string) ([]byte, error) {
 	bucketName, err := file.DefaultBucketName(ctx)
 	if err != nil {
 		return nil, err

--- a/backend/oauth.go
+++ b/backend/oauth.go
@@ -27,6 +27,8 @@ const (
 func InitOAuth() {
 	RegisterHandler(OAUTH_BASE+"login/google", oauth.GoogleLogin)
 	RegisterHandler(OAUTH_BASE+"callback/google", oauth.GoogleCallback)
+	RegisterHandler(OAUTH_BASE+"login/github", oauth.GitHubLogin)
+	RegisterHandler(OAUTH_BASE+"callback/github", oauth.GitHubCallback)
 	RegisterHandler(OAUTH_BASE+"status", oauthStatus)
 	RegisterHandler(OAUTH_BASE+"logout", oauth.Logout)
 }

--- a/backend/oauth.go
+++ b/backend/oauth.go
@@ -15,8 +15,11 @@
 package backend
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"net/http"
 
+	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/appengine"
@@ -25,24 +28,24 @@ import (
 const (
 	OAUTH_BASE = "/oauth/"
 
-	OAUTH_COOKIE_RETURN = "oauth2_return"
-	OAUTH_COOKIE_STATE  = "oauth2_state"
+	OAUTH_COOKIE = "oauth2_cookie"
+
+	CLIENT_SECRET_GOOGLE_FILENAME = "google_client_secret.json"
 )
 
-var oauthGoogleConfig = &oauth2.Config{
-	ClientID:     "942246668199-hsrojq1smecb0srckt3dk86orr3u1c9r.apps.googleusercontent.com",
-	ClientSecret: "agmDbkxD-mW4Lqk0kGtiEsvi",
-	Scopes:       []string{"openid", "profile"},
-	Endpoint:     google.Endpoint,
-	RedirectURL:  "https://abe-staging.appspot.com/oauth/google/callback",
-}
+var (
+	oauthScopes       = []string{"openid", "profile"}
+	oauthGoogleConfig *oauth2.Config
+)
 
 func InitOAuth() {
 	RegisterHandler(OAUTH_BASE+"google/login", oauthGoogleLogin)
 	RegisterHandler(OAUTH_BASE+"google/callback", oauthGoogleCallback)
+	RegisterHandler(OAUTH_BASE+"status", oauthStatus)
+	RegisterHandler(OAUTH_BASE+"logout", oauthLogout)
 }
 
-func oauthGoogleLogin(w http.ResponseWriter, r *http.Request) {
+func oauthLoginForConfig(w http.ResponseWriter, r *http.Request, config *oauth2.Config) {
 	returnURL := r.URL.Query().Get("return")
 	if returnURL == "" {
 		http.Error(w, "Missing return URL", http.StatusBadRequest)
@@ -50,27 +53,43 @@ func oauthGoogleLogin(w http.ResponseWriter, r *http.Request) {
 	}
 
 	state := RandomString(8)
-	url := oauthGoogleConfig.AuthCodeURL(state)
+	url := config.AuthCodeURL(state)
 
-	oauthCookieToResponse(w, &oauthCookie{
+	cookieData := &oauthCookie{
 		State:     state,
-		returnURL: returnURL,
-	})
-
-	http.Redirect(w, r, url, http.StatusSeeOther)
-}
-
-func oauthGoogleCallback(w http.ResponseWriter, r *http.Request) {
-	query := r.URL.Query()
-
-	cookie, err := oauthCookieFromRequest(r)
+		ReturnURL: returnURL,
+	}
+	cookie, err := cookieData.ToCookie()
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		http.Error(w, "Failed to create cookie", http.StatusInternalServerError)
 		return
 	}
-	oauthCookieDelete(w)
 
-	state := cookie.State
+	http.SetCookie(w, cookie)
+	http.Redirect(w, r, url, http.StatusFound)
+}
+
+func oauthGoogleLogin(w http.ResponseWriter, r *http.Request) {
+	ctx := appengine.NewContext(r)
+	config, err := getOauthGoogleConfig(ctx)
+	if err != nil {
+		http.Error(w, "Failed to get OAuth2 config", http.StatusInternalServerError)
+		return
+	}
+
+	oauthLoginForConfig(w, r, config)
+}
+
+func oauthCallbackForConfig(w http.ResponseWriter, r *http.Request, config *oauth2.Config, provider string) {
+	query := r.URL.Query()
+
+	cookieData, err := oauthCookieFromRequest(r)
+	if err != nil {
+		http.Error(w, "Invalid cookie", http.StatusInternalServerError)
+		return
+	}
+
+	state := cookieData.State
 	if query.Get("state") != state {
 		http.Error(w, "Invalid OAuth2 state", http.StatusBadRequest)
 		return
@@ -83,67 +102,135 @@ func oauthGoogleCallback(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ctx := appengine.NewContext(r)
-	token, err := oauthGoogleConfig.Exchange(ctx, code)
+	token, err := config.Exchange(ctx, code)
 	if err != nil {
-		http.Redirect(w, r, cookie.ReturnURL(false), http.StatusSeeOther)
+		oauthCookieClear(w)
+		http.Redirect(w, r, cookieData.GenerateReturnURL(false), http.StatusFound)
 		return
 	}
 	if !token.Valid() {
-		http.Redirect(w, r, cookie.ReturnURL(false), http.StatusSeeOther)
+		oauthCookieClear(w)
+		http.Redirect(w, r, cookieData.GenerateReturnURL(false), http.StatusFound)
 		return
 	}
 
-	http.Redirect(w, r, cookie.ReturnURL(true), http.StatusSeeOther)
+	url := cookieData.GenerateReturnURL(true)
+	cookieData = &oauthCookie{
+		LoggedInWith: provider,
+		Token:        token,
+	}
+	cookie, err := cookieData.ToCookie()
+	if err != nil {
+		http.Error(w, "Failed to create cookie", http.StatusInternalServerError)
+		return
+	}
+
+	http.SetCookie(w, cookie)
+	http.Redirect(w, r, url, http.StatusFound)
+}
+
+func oauthGoogleCallback(w http.ResponseWriter, r *http.Request) {
+	ctx := appengine.NewContext(r)
+	config, err := getOauthGoogleConfig(ctx)
+	if err != nil {
+		http.Error(w, "Failed to get OAuth2 config", http.StatusInternalServerError)
+		return
+	}
+
+	oauthCallbackForConfig(w, r, config, "google")
+}
+
+func oauthStatus(w http.ResponseWriter, r *http.Request) {
+	loggedIn := false
+	cookie, err := oauthCookieFromRequest(r)
+	if err == nil {
+		loggedIn = cookie.LoggedInWith != ""
+	}
+
+	SendJsonResponse(w, map[string]interface{}{
+		"loggedIn": loggedIn,
+	})
+}
+
+func oauthLogout(w http.ResponseWriter, r *http.Request) {
+	returnURL := r.URL.Query().Get("return")
+	if returnURL == "" {
+		http.Error(w, "Missing return URL", http.StatusBadRequest)
+		return
+	}
+	returnURL += "#success=true"
+
+	oauthCookieClear(w)
+	http.Redirect(w, r, returnURL, http.StatusFound)
 }
 
 type oauthCookie struct {
-	State     string
-	returnURL string
+	State        string
+	ReturnURL    string
+	LoggedInWith string
+	Token        *oauth2.Token
 }
 
-func (c *oauthCookie) ReturnURL(success bool) string {
+func (c *oauthCookie) GenerateReturnURL(success bool) string {
 	if !success {
-		return c.returnURL + "#success=false"
+		return c.ReturnURL + "#success=false"
 	}
-	return c.returnURL + "#success=true"
+	return c.ReturnURL + "#success=true"
 }
 
-func oauthCookieToResponse(w http.ResponseWriter, cookie *oauthCookie) {
-	http.SetCookie(w, &http.Cookie{
-		Name:  OAUTH_COOKIE_STATE,
-		Value: cookie.State,
-	})
-	http.SetCookie(w, &http.Cookie{
-		Name:  OAUTH_COOKIE_RETURN,
-		Value: cookie.returnURL,
-	})
+func (c *oauthCookie) ToCookie() (*http.Cookie, error) {
+	dataJson, err := json.Marshal(c)
+	if err != nil {
+		return nil, err
+	}
+	return &http.Cookie{
+		Name:     OAUTH_COOKIE,
+		Value:    base64.RawStdEncoding.EncodeToString(dataJson),
+		Path:     OAUTH_BASE,
+		HttpOnly: true,
+	}, nil
 }
 
 func oauthCookieFromRequest(r *http.Request) (*oauthCookie, error) {
-	var cookieData oauthCookie
-
-	cookie, err := r.Cookie(OAUTH_COOKIE_STATE)
+	cookie, err := r.Cookie(OAUTH_COOKIE)
 	if err != nil {
 		return nil, err
 	}
-	cookieData.State = cookie.Value
-
-	cookie, err = r.Cookie(OAUTH_COOKIE_RETURN)
+	data, err := base64.RawStdEncoding.DecodeString(cookie.Value)
 	if err != nil {
 		return nil, err
 	}
-	cookieData.returnURL = cookie.Value
 
-	return &cookieData, nil
+	var out oauthCookie
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
 }
 
-func oauthCookieDelete(w http.ResponseWriter) {
+func oauthCookieClear(w http.ResponseWriter) {
 	http.SetCookie(w, &http.Cookie{
-		Name:   OAUTH_COOKIE_STATE,
-		MaxAge: -1,
+		Name:     OAUTH_COOKIE,
+		Path:     OAUTH_BASE,
+		HttpOnly: true,
+		MaxAge:   -1,
 	})
-	http.SetCookie(w, &http.Cookie{
-		Name:   OAUTH_COOKIE_RETURN,
-		MaxAge: -1,
-	})
+}
+
+func getOauthGoogleConfig(ctx context.Context) (*oauth2.Config, error) {
+	if oauthGoogleConfig != nil {
+		return oauthGoogleConfig, nil
+	}
+
+	secret, err := readFileFromDatastore(ctx, CLIENT_SECRET_GOOGLE_FILENAME)
+	if err != nil {
+		return nil, err
+	}
+
+	oauthGoogleConfig, err = google.ConfigFromJSON(secret, oauthScopes...)
+	if err != nil {
+		return nil, err
+	}
+
+	return oauthGoogleConfig, nil
 }

--- a/backend/oauth.go
+++ b/backend/oauth.go
@@ -15,222 +15,25 @@
 package backend
 
 import (
-	"encoding/base64"
-	"encoding/json"
-	"net/http"
+	"backend/oauth"
 
-	"golang.org/x/net/context"
-	"golang.org/x/oauth2"
-	"golang.org/x/oauth2/google"
-	"google.golang.org/appengine"
+	"net/http"
 )
 
 const (
 	OAUTH_BASE = "/oauth/"
-
-	OAUTH_COOKIE = "oauth2_cookie"
-
-	CLIENT_SECRET_GOOGLE_FILENAME = "google_client_secret.json"
-)
-
-var (
-	oauthScopes       = []string{"openid", "profile"}
-	oauthGoogleConfig *oauth2.Config
 )
 
 func InitOAuth() {
-	RegisterHandler(OAUTH_BASE+"google/login", oauthGoogleLogin)
-	RegisterHandler(OAUTH_BASE+"google/callback", oauthGoogleCallback)
+	RegisterHandler(OAUTH_BASE+"login/google", oauth.GoogleLogin)
+	RegisterHandler(OAUTH_BASE+"callback/google", oauth.GoogleCallback)
 	RegisterHandler(OAUTH_BASE+"status", oauthStatus)
-	RegisterHandler(OAUTH_BASE+"logout", oauthLogout)
-}
-
-func oauthLoginForConfig(w http.ResponseWriter, r *http.Request, config *oauth2.Config) {
-	returnURL := r.URL.Query().Get("return")
-	if returnURL == "" {
-		http.Error(w, "Missing return URL", http.StatusBadRequest)
-		return
-	}
-
-	state := RandomString(8)
-	url := config.AuthCodeURL(state)
-
-	cookieData := &oauthCookie{
-		State:     state,
-		ReturnURL: returnURL,
-	}
-	cookie, err := cookieData.ToCookie()
-	if err != nil {
-		http.Error(w, "Failed to create cookie", http.StatusInternalServerError)
-		return
-	}
-
-	http.SetCookie(w, cookie)
-	http.Redirect(w, r, url, http.StatusFound)
-}
-
-func oauthGoogleLogin(w http.ResponseWriter, r *http.Request) {
-	ctx := appengine.NewContext(r)
-	config, err := getOauthGoogleConfig(ctx)
-	if err != nil {
-		http.Error(w, "Failed to get OAuth2 config", http.StatusInternalServerError)
-		return
-	}
-
-	oauthLoginForConfig(w, r, config)
-}
-
-func oauthCallbackForConfig(w http.ResponseWriter, r *http.Request, config *oauth2.Config, provider string) {
-	query := r.URL.Query()
-
-	cookieData, err := oauthCookieFromRequest(r)
-	if err != nil {
-		http.Error(w, "Invalid cookie", http.StatusInternalServerError)
-		return
-	}
-
-	state := cookieData.State
-	if query.Get("state") != state {
-		http.Error(w, "Invalid OAuth2 state", http.StatusBadRequest)
-		return
-	}
-
-	code := query.Get("code")
-	if code == "" {
-		http.Error(w, "Missing OAuth2 code", http.StatusBadRequest)
-		return
-	}
-
-	ctx := appengine.NewContext(r)
-	token, err := config.Exchange(ctx, code)
-	if err != nil {
-		oauthCookieClear(w)
-		http.Redirect(w, r, cookieData.GenerateReturnURL(false), http.StatusFound)
-		return
-	}
-	if !token.Valid() {
-		oauthCookieClear(w)
-		http.Redirect(w, r, cookieData.GenerateReturnURL(false), http.StatusFound)
-		return
-	}
-
-	url := cookieData.GenerateReturnURL(true)
-	cookieData = &oauthCookie{
-		LoggedInWith: provider,
-		Token:        token,
-	}
-	cookie, err := cookieData.ToCookie()
-	if err != nil {
-		http.Error(w, "Failed to create cookie", http.StatusInternalServerError)
-		return
-	}
-
-	http.SetCookie(w, cookie)
-	http.Redirect(w, r, url, http.StatusFound)
-}
-
-func oauthGoogleCallback(w http.ResponseWriter, r *http.Request) {
-	ctx := appengine.NewContext(r)
-	config, err := getOauthGoogleConfig(ctx)
-	if err != nil {
-		http.Error(w, "Failed to get OAuth2 config", http.StatusInternalServerError)
-		return
-	}
-
-	oauthCallbackForConfig(w, r, config, "google")
+	RegisterHandler(OAUTH_BASE+"logout", oauth.Logout)
 }
 
 func oauthStatus(w http.ResponseWriter, r *http.Request) {
-	loggedIn := false
-	cookie, err := oauthCookieFromRequest(r)
-	if err == nil {
-		loggedIn = cookie.LoggedInWith != ""
-	}
-
+	token := oauth.GetToken(r)
 	SendJsonResponse(w, map[string]interface{}{
-		"loggedIn": loggedIn,
+		"loggedIn": token != nil,
 	})
-}
-
-func oauthLogout(w http.ResponseWriter, r *http.Request) {
-	returnURL := r.URL.Query().Get("return")
-	if returnURL == "" {
-		http.Error(w, "Missing return URL", http.StatusBadRequest)
-		return
-	}
-	returnURL += "#success=true"
-
-	oauthCookieClear(w)
-	http.Redirect(w, r, returnURL, http.StatusFound)
-}
-
-type oauthCookie struct {
-	State        string
-	ReturnURL    string
-	LoggedInWith string
-	Token        *oauth2.Token
-}
-
-func (c *oauthCookie) GenerateReturnURL(success bool) string {
-	if !success {
-		return c.ReturnURL + "#success=false"
-	}
-	return c.ReturnURL + "#success=true"
-}
-
-func (c *oauthCookie) ToCookie() (*http.Cookie, error) {
-	dataJson, err := json.Marshal(c)
-	if err != nil {
-		return nil, err
-	}
-	return &http.Cookie{
-		Name:     OAUTH_COOKIE,
-		Value:    base64.RawStdEncoding.EncodeToString(dataJson),
-		Path:     OAUTH_BASE,
-		HttpOnly: true,
-	}, nil
-}
-
-func oauthCookieFromRequest(r *http.Request) (*oauthCookie, error) {
-	cookie, err := r.Cookie(OAUTH_COOKIE)
-	if err != nil {
-		return nil, err
-	}
-	data, err := base64.RawStdEncoding.DecodeString(cookie.Value)
-	if err != nil {
-		return nil, err
-	}
-
-	var out oauthCookie
-	if err := json.Unmarshal(data, &out); err != nil {
-		return nil, err
-	}
-	return &out, nil
-}
-
-func oauthCookieClear(w http.ResponseWriter) {
-	http.SetCookie(w, &http.Cookie{
-		Name:     OAUTH_COOKIE,
-		Path:     OAUTH_BASE,
-		HttpOnly: true,
-		MaxAge:   -1,
-	})
-}
-
-func getOauthGoogleConfig(ctx context.Context) (*oauth2.Config, error) {
-	if oauthGoogleConfig != nil {
-		return oauthGoogleConfig, nil
-	}
-
-	secret, err := readFileFromDatastore(ctx, CLIENT_SECRET_GOOGLE_FILENAME)
-	if err != nil {
-		return nil, err
-	}
-
-	oauthGoogleConfig, err = google.ConfigFromJSON(secret, oauthScopes...)
-	if err != nil {
-		return nil, err
-	}
-
-	return oauthGoogleConfig, nil
 }

--- a/backend/oauth.go
+++ b/backend/oauth.go
@@ -1,0 +1,149 @@
+// Copyright Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backend
+
+import (
+	"net/http"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+	"google.golang.org/appengine"
+)
+
+const (
+	OAUTH_BASE = "/oauth/"
+
+	OAUTH_COOKIE_RETURN = "oauth2_return"
+	OAUTH_COOKIE_STATE  = "oauth2_state"
+)
+
+var oauthGoogleConfig = &oauth2.Config{
+	ClientID:     "942246668199-hsrojq1smecb0srckt3dk86orr3u1c9r.apps.googleusercontent.com",
+	ClientSecret: "agmDbkxD-mW4Lqk0kGtiEsvi",
+	Scopes:       []string{"openid", "profile"},
+	Endpoint:     google.Endpoint,
+	RedirectURL:  "https://abe-staging.appspot.com/oauth/google/callback",
+}
+
+func InitOAuth() {
+	RegisterHandler(OAUTH_BASE+"google/login", oauthGoogleLogin)
+	RegisterHandler(OAUTH_BASE+"google/callback", oauthGoogleCallback)
+}
+
+func oauthGoogleLogin(w http.ResponseWriter, r *http.Request) {
+	returnURL := r.URL.Query().Get("return")
+	if returnURL == "" {
+		http.Error(w, "Missing return URL", http.StatusBadRequest)
+		return
+	}
+
+	state := RandomString(8)
+	url := oauthGoogleConfig.AuthCodeURL(state)
+
+	oauthCookieToResponse(w, &oauthCookie{
+		State:     state,
+		returnURL: returnURL,
+	})
+
+	http.Redirect(w, r, url, http.StatusSeeOther)
+}
+
+func oauthGoogleCallback(w http.ResponseWriter, r *http.Request) {
+	query := r.URL.Query()
+
+	cookie, err := oauthCookieFromRequest(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	oauthCookieDelete(w)
+
+	state := cookie.State
+	if query.Get("state") != state {
+		http.Error(w, "Invalid OAuth2 state", http.StatusBadRequest)
+		return
+	}
+
+	code := query.Get("code")
+	if code == "" {
+		http.Error(w, "Missing OAuth2 code", http.StatusBadRequest)
+		return
+	}
+
+	ctx := appengine.NewContext(r)
+	token, err := oauthGoogleConfig.Exchange(ctx, code)
+	if err != nil {
+		http.Redirect(w, r, cookie.ReturnURL(false), http.StatusSeeOther)
+		return
+	}
+	if !token.Valid() {
+		http.Redirect(w, r, cookie.ReturnURL(false), http.StatusSeeOther)
+		return
+	}
+
+	http.Redirect(w, r, cookie.ReturnURL(true), http.StatusSeeOther)
+}
+
+type oauthCookie struct {
+	State     string
+	returnURL string
+}
+
+func (c *oauthCookie) ReturnURL(success bool) string {
+	if !success {
+		return c.returnURL + "#success=false"
+	}
+	return c.returnURL + "#success=true"
+}
+
+func oauthCookieToResponse(w http.ResponseWriter, cookie *oauthCookie) {
+	http.SetCookie(w, &http.Cookie{
+		Name:  OAUTH_COOKIE_STATE,
+		Value: cookie.State,
+	})
+	http.SetCookie(w, &http.Cookie{
+		Name:  OAUTH_COOKIE_RETURN,
+		Value: cookie.returnURL,
+	})
+}
+
+func oauthCookieFromRequest(r *http.Request) (*oauthCookie, error) {
+	var cookieData oauthCookie
+
+	cookie, err := r.Cookie(OAUTH_COOKIE_STATE)
+	if err != nil {
+		return nil, err
+	}
+	cookieData.State = cookie.Value
+
+	cookie, err = r.Cookie(OAUTH_COOKIE_RETURN)
+	if err != nil {
+		return nil, err
+	}
+	cookieData.returnURL = cookie.Value
+
+	return &cookieData, nil
+}
+
+func oauthCookieDelete(w http.ResponseWriter) {
+	http.SetCookie(w, &http.Cookie{
+		Name:   OAUTH_COOKIE_STATE,
+		MaxAge: -1,
+	})
+	http.SetCookie(w, &http.Cookie{
+		Name:   OAUTH_COOKIE_RETURN,
+		MaxAge: -1,
+	})
+}

--- a/backend/oauth.go
+++ b/backend/oauth.go
@@ -34,8 +34,9 @@ func InitOAuth() {
 }
 
 func oauthStatus(w http.ResponseWriter, r *http.Request) {
-	token := oauth.GetToken(r)
+	name := oauth.GetUserName(r)
 	SendJsonResponse(w, map[string]interface{}{
-		"loggedIn": token != nil,
+		"loggedIn": name != "",
+		"name":     name,
 	})
 }

--- a/backend/oauth/github.go
+++ b/backend/oauth/github.go
@@ -1,0 +1,85 @@
+// Copyright Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oauth
+
+import (
+	"backend/datastore"
+	"encoding/json"
+
+	"net/http"
+
+	"golang.org/x/net/context"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/github"
+	"google.golang.org/appengine"
+)
+
+const (
+	CLIENT_SECRET_GITHUB_FILENAME = "github_client_secret.json"
+)
+
+var (
+	oauthGitHubScopes = []string{"openid", "profile"}
+	oauthGitHubConfig *oauth2.Config
+)
+
+func GitHubLogin(w http.ResponseWriter, r *http.Request) {
+	ctx := appengine.NewContext(r)
+	config, err := fetchOauthGitHubConfig(ctx)
+	if err != nil {
+		http.Error(w, "Failed to get OAuth2 config", http.StatusInternalServerError)
+		return
+	}
+
+	loginForConfig(w, r, config)
+}
+
+func GitHubCallback(w http.ResponseWriter, r *http.Request) {
+	ctx := appengine.NewContext(r)
+	config, err := fetchOauthGitHubConfig(ctx)
+	if err != nil {
+		http.Error(w, "Failed to get OAuth2 config", http.StatusInternalServerError)
+		return
+	}
+
+	callbackForConfig(w, r, config, "github")
+}
+
+func fetchOauthGitHubConfig(ctx context.Context) (*oauth2.Config, error) {
+	if oauthGitHubConfig != nil {
+		return oauthGitHubConfig, nil
+	}
+
+	secretJSON, err := datastore.ReadFile(ctx, CLIENT_SECRET_GITHUB_FILENAME)
+	if err != nil {
+		return nil, err
+	}
+
+	var secret map[string]string
+	err = json.Unmarshal(secretJSON, &secret)
+	if err != nil {
+		return nil, err
+	}
+
+	oauthGitHubConfig = &oauth2.Config{
+		ClientID:     secret["client_id"],
+		ClientSecret: secret["client_secret"],
+		RedirectURL:  secret["redirect_uri"],
+		Scopes:       oauthGitHubScopes,
+		Endpoint:     github.Endpoint,
+	}
+
+	return oauthGitHubConfig, nil
+}

--- a/backend/oauth/google.go
+++ b/backend/oauth/google.go
@@ -1,0 +1,75 @@
+// Copyright Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oauth
+
+import (
+	"backend/datastore"
+
+	"net/http"
+
+	"golang.org/x/net/context"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+	"google.golang.org/appengine"
+)
+
+const (
+	CLIENT_SECRET_GOOGLE_FILENAME = "google_client_secret.json"
+)
+
+var (
+	oauthGoogleScopes = []string{"openid", "profile"}
+	oauthGoogleConfig *oauth2.Config
+)
+
+func GoogleLogin(w http.ResponseWriter, r *http.Request) {
+	ctx := appengine.NewContext(r)
+	config, err := fetchOauthGoogleConfig(ctx)
+	if err != nil {
+		http.Error(w, "Failed to get OAuth2 config", http.StatusInternalServerError)
+		return
+	}
+
+	loginForConfig(w, r, config)
+}
+
+func GoogleCallback(w http.ResponseWriter, r *http.Request) {
+	ctx := appengine.NewContext(r)
+	config, err := fetchOauthGoogleConfig(ctx)
+	if err != nil {
+		http.Error(w, "Failed to get OAuth2 config", http.StatusInternalServerError)
+		return
+	}
+
+	callbackForConfig(w, r, config, "google")
+}
+
+func fetchOauthGoogleConfig(ctx context.Context) (*oauth2.Config, error) {
+	if oauthGoogleConfig != nil {
+		return oauthGoogleConfig, nil
+	}
+
+	secret, err := datastore.ReadFile(ctx, CLIENT_SECRET_GOOGLE_FILENAME)
+	if err != nil {
+		return nil, err
+	}
+
+	oauthGoogleConfig, err = google.ConfigFromJSON(secret, oauthGoogleScopes...)
+	if err != nil {
+		return nil, err
+	}
+
+	return oauthGoogleConfig, nil
+}

--- a/backend/oauth/oauth.go
+++ b/backend/oauth/oauth.go
@@ -1,0 +1,133 @@
+// Copyright Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oauth
+
+import (
+	"backend/cookie"
+	"backend/util"
+
+	"net/http"
+	"strconv"
+
+	"golang.org/x/oauth2"
+	"google.golang.org/appengine"
+)
+
+const (
+	OAUTH_COOKIE = "oauth2_cookie"
+)
+
+func loginForConfig(w http.ResponseWriter, r *http.Request, config *oauth2.Config) {
+	returnURL := r.URL.Query().Get("return")
+	if returnURL == "" {
+		http.Error(w, "Missing return URL", http.StatusBadRequest)
+		return
+	}
+
+	state := util.RandomString(8)
+	url := config.AuthCodeURL(state)
+
+	cookieData := &oauthCookie{
+		State:     state,
+		ReturnURL: returnURL,
+	}
+	if err := cookie.Set(w, OAUTH_COOKIE, cookieData); err != nil {
+		http.Error(w, "Failed to set cookie", http.StatusInternalServerError)
+		return
+	}
+
+	http.Redirect(w, r, url, http.StatusFound)
+}
+
+func callbackForConfig(w http.ResponseWriter, r *http.Request, config *oauth2.Config, provider string) {
+	query := r.URL.Query()
+
+	var cookieData oauthCookie
+	if err := cookie.Get(r, OAUTH_COOKIE, &cookieData); err != nil {
+		http.Error(w, "Invalid cookie", http.StatusInternalServerError)
+		return
+	}
+
+	state := cookieData.State
+	if query.Get("state") != state {
+		http.Error(w, "Invalid OAuth2 state", http.StatusBadRequest)
+		return
+	}
+
+	code := query.Get("code")
+	if code == "" {
+		http.Error(w, "Missing OAuth2 code", http.StatusBadRequest)
+		return
+	}
+
+	ctx := appengine.NewContext(r)
+	token, err := config.Exchange(ctx, code)
+	if err != nil {
+		cookie.Clear(w, OAUTH_COOKIE)
+		http.Redirect(w, r, cookieData.generateReturnURL(false), http.StatusFound)
+		return
+	}
+	if !token.Valid() {
+		cookie.Clear(w, OAUTH_COOKIE)
+		http.Redirect(w, r, cookieData.generateReturnURL(false), http.StatusFound)
+		return
+	}
+
+	url := cookieData.generateReturnURL(true)
+	cookieData = oauthCookie{
+		LoggedInWith: provider,
+		Token:        token,
+	}
+	if err := cookie.Set(w, OAUTH_COOKIE, &cookieData); err != nil {
+		http.Error(w, "Failed to set cookie", http.StatusInternalServerError)
+		return
+	}
+
+	http.Redirect(w, r, url, http.StatusFound)
+}
+
+func GetToken(r *http.Request) *oauth2.Token {
+	var cookieData oauthCookie
+	if err := cookie.Get(r, OAUTH_COOKIE, &cookieData); err != nil {
+		return nil
+	}
+	if !cookieData.Token.Valid() {
+		return nil
+	}
+	return cookieData.Token
+}
+
+func Logout(w http.ResponseWriter, r *http.Request) {
+	returnURL := r.URL.Query().Get("return")
+	if returnURL == "" {
+		http.Error(w, "Missing return URL", http.StatusBadRequest)
+		return
+	}
+	returnURL += "#success=true"
+
+	cookie.Clear(w, OAUTH_COOKIE)
+	http.Redirect(w, r, returnURL, http.StatusFound)
+}
+
+type oauthCookie struct {
+	State        string
+	ReturnURL    string
+	LoggedInWith string
+	Token        *oauth2.Token
+}
+
+func (c *oauthCookie) generateReturnURL(success bool) string {
+	return c.ReturnURL + "#success=" + strconv.FormatBool(success)
+}

--- a/backend/util/strings.go
+++ b/backend/util/strings.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package backend
+package util
 
 import (
 	"math/rand"

--- a/server.go
+++ b/server.go
@@ -43,6 +43,7 @@ func init() {
 	backend.InitAmpStoryAutoAds()
 	backend.InitLetsEncrypt()
 	backend.InitSeatmapPage()
+	backend.InitOAuth()
 	playground.InitPlayground()
 	backend.InitStatic()
 	http.HandleFunc("/_ah/warmup", warmup)

--- a/src/60_Samples_%26_Templates/Comment_Section.html
+++ b/src/60_Samples_%26_Templates/Comment_Section.html
@@ -85,7 +85,7 @@ This sample showcases how to build a comment section in AMP HTML using the [amp-
         "authorization": "<%host%>/oauth/status",
         "noPingback": "true",
         "login": {
-          "google-sign-in": "<%host%>/oauth/google/login",
+          "google-sign-in": "<%host%>/oauth/login/google",
           "sign-out": "<%host%>/oauth/logout"
         },
         "authorizationFallbackResponse": {

--- a/src/60_Samples_%26_Templates/Comment_Section.html
+++ b/src/60_Samples_%26_Templates/Comment_Section.html
@@ -86,6 +86,7 @@ This sample showcases how to build a comment section in AMP HTML using the [amp-
         "noPingback": "true",
         "login": {
           "google-sign-in": "<%host%>/oauth/login/google",
+          "github-sign-in": "<%host%>/oauth/login/github",
           "sign-out": "<%host%>/oauth/logout"
         },
         "authorizationFallbackResponse": {
@@ -128,6 +129,7 @@ This sample showcases how to build a comment section in AMP HTML using the [amp-
     <span amp-access="NOT loggedIn" role="button" tabindex="0" amp-access-hide>
           <h3 class="m1">Please login to comment</h3>
           <button on="tap:amp-access.login-google-sign-in" class="ampstart-btn m2 caps">Google Login</button>
+          <button on="tap:amp-access.login-github-sign-in" class="ampstart-btn m2 caps">GitHub Login</button>
     </span>
       <!-- Use amp-form to submit the comment. In this sample, only a single comment can be added as comments are not persisted in the backend.  -->
       <form class="px1 pt1 flex" amp-access="loggedIn" amp-access-hide method="post" action-xhr="/samples_templates/comment_section/submit-comment-xhr" target="_top">

--- a/src/60_Samples_%26_Templates/Comment_Section.html
+++ b/src/60_Samples_%26_Templates/Comment_Section.html
@@ -82,11 +82,11 @@ This sample showcases how to build a comment section in AMP HTML using the [amp-
           This sample allows an user to login and logout using an email and a password. Logout is implemented by configuring a second endpoint in the login property `sign-out`, find more [here](https://www.ampproject.org/docs/reference/components/amp-access#login-page).  -->
     <script id="amp-access" type="application/json">
     {
-        "authorization": "<%host%>/samples_templates/comment_section/authorization?rid=READER_ID&url=CANONICAL_URL&ref=DOCUMENT_REFERRER&_=RANDOM",
+        "authorization": "<%host%>/oauth/status",
         "noPingback": "true",
         "login": {
-          "sign-in": "<%host%>/samples_templates/comment_section/login?rid=READER_ID",
-          "sign-out": "<%host%>/samples_templates/comment_section/logout?rid=READER_ID"
+          "google-sign-in": "<%host%>/oauth/google/login",
+          "sign-out": "<%host%>/oauth/logout"
         },
         "authorizationFallbackResponse": {
             "error": true,
@@ -122,12 +122,12 @@ This sample showcases how to build a comment section in AMP HTML using the [amp-
           </div>
       </amp-list>
 
-    <!-- In order to add comments users need to be logged in. We use `amp-access` to integrate login and to show and hide the login button depending on whether the user is logged in. `on="tap:amp-access.login-sign-in"` specifies which
-    action should be taken when clicking on the login button: `login` defines the property inside the `amp-access` json configuration, while `sign-in` defines
+    <!-- In order to add comments users need to be logged in. We use `amp-access` to integrate login and to show and hide the login button depending on whether the user is logged in. `on="tap:amp-access.login-google-sign-in"` specifies which
+    action should be taken when clicking on the login button: `login` defines the property inside the `amp-access` json configuration, while `google-sign-in` defines
     the endpoint. -->
     <span amp-access="NOT loggedIn" role="button" tabindex="0" amp-access-hide>
           <h3 class="m1">Please login to comment</h3>
-          <button on="tap:amp-access.login-sign-in" class="ampstart-btn m2 caps">Login</button>
+          <button on="tap:amp-access.login-google-sign-in" class="ampstart-btn m2 caps">Google Login</button>
     </span>
       <!-- Use amp-form to submit the comment. In this sample, only a single comment can be added as comments are not persisted in the backend.  -->
       <form class="px1 pt1 flex" amp-access="loggedIn" amp-access-hide method="post" action-xhr="/samples_templates/comment_section/submit-comment-xhr" target="_top">

--- a/static/sw.js
+++ b/static/sw.js
@@ -24,7 +24,8 @@ const IGNORED_URLS = [
   /.*\/shopping_cart$/,
   /.*\/favorite$/,
   /.*\/favorite-with-count$/,
-  /.*\/slow-json-with-items$/
+  /.*\/slow-json-with-items$/,
+  /.*\/oauth\//
 ];
 
 config.filesToCache = [


### PR DESCRIPTION
This PR replaces the OAuth2 flow in the comments sample with a server-side based one, which is smoother in the context of `amp-access`.

Currently, only a Google sign-in is supported, but adding another OAuth2 provider in the future should be almost trivial, as the only thing needed is an [`oauth2.Config`](https://godoc.org/golang.org/x/oauth2#Config) object.