### PR TITLE
Spell it 'tomatoes' not 'tomatos'

### DIFF
--- a/src/50_Visual_Effects/Basics_of_scrollbound_effects.html
+++ b/src/50_Visual_Effects/Basics_of_scrollbound_effects.html
@@ -212,7 +212,7 @@
 
     <amp-fit-text layout="fill">
       <div class="card-title">
-        Organic, fresh tomatos and pasta!
+        Organic, fresh tomatoes and pasta!
       </div>
     </amp-fit-text>
 


### PR DESCRIPTION
As requested in https://github.com/ampproject/amphtml/pull/17769#issuecomment-417019206