### PR TITLE
Update custom styling example for amp-carousel buttons

### DIFF
--- a/src/20_Components/amp-carousel.html
+++ b/src/20_Components/amp-carousel.html
@@ -31,10 +31,6 @@
     .red-box {
       background: red;
     }
-    .amp-carousel-button-prev {
-      left: 5%;
-      background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18"><path d="M11.56 5.56L10.5 4.5 6 9l4.5 4.5 1.06-1.06L8.12 9z" fill="#fff" /></svg>');
-  }
   </style>
 </head>
 <body>

--- a/src/20_Components/amp-carousel.html
+++ b/src/20_Components/amp-carousel.html
@@ -31,6 +31,14 @@
     .red-box {
       background: red;
     }
+    #custom-button .amp-carousel-button-prev {
+      left: 5%;
+      background-image: url('data:image/svg+xml;charset=utf-8,<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path  d="M14,7.4 L9.4,12 L14,16.6" fill="none" stroke="#fff" stroke-width="2px" stroke-linejoin="round" stroke-linecap="round" /></svg>');
+    }
+    #custom-button .amp-carousel-button-next {
+      right: 5%;
+      background-image: url('data:image/svg+xml;charset=utf-8,<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path  d="M10,7.4 L14.6,12 L10,16.6" fill="none" stroke="#fff" stroke-width="2px" stroke-linejoin="round" stroke-linecap="round" /></svg>');
+    }
   </style>
 </head>
 <body>
@@ -58,13 +66,13 @@
     <amp-img src="/img/image3.jpg" width="400" height="300" layout="responsive" alt="and another sample image"></amp-img>
   </amp-carousel>
 
-    <!-- By default, `amp-carousel-button` uses an inlined SVG as the background-image of the buttons. 
-      You may override this with your own SVG or image by using .amp-carousel-button-prev class. -->
-    <amp-carousel width="400" height="300" layout="responsive" type="slides" autoplay delay="2000">
-      <amp-img src="/img/image1.jpg" width="400" height="300" layout="responsive" alt="a sample image"></amp-img>
-      <amp-img src="/img/image2.jpg" width="400" height="300" layout="responsive" alt="another sample image"></amp-img>
-      <amp-img src="/img/image3.jpg" width="400" height="300" layout="responsive" alt="and another sample image"></amp-img>
-    </amp-carousel>
+  <!-- By default, carousel buttons use inlined SVGs as background-images.
+    You may override these with your own SVGs or images by using `.amp-carousel-button-prev` and `.amp-carousel-button-next` classes. -->
+  <amp-carousel id="custom-button" width="400" height="300" layout="responsive" type="slides" autoplay delay="2000">
+    <amp-img src="/img/image1.jpg" width="400" height="300" layout="responsive" alt="a sample image"></amp-img>
+    <amp-img src="/img/image2.jpg" width="400" height="300" layout="responsive" alt="another sample image"></amp-img>
+    <amp-img src="/img/image3.jpg" width="400" height="300" layout="responsive" alt="and another sample image"></amp-img>
+  </amp-carousel>
 
   <!-- ## Supported Contents  -->
   <!-- Each of these nodes may also have arbitrary HTML children.  -->


### PR DESCRIPTION
- [x] Create styling rules that does not affect all carousels and make them look broken

Originally: 
<img width="567" alt="screen shot 2018-08-31 at 11 52 36 am" src="https://user-images.githubusercontent.com/15007517/44930835-6c233d00-ad14-11e8-8352-f1c349105655.png">

After fix:
<img width="530" alt="screen shot 2018-08-31 at 11 52 17 am" src="https://user-images.githubusercontent.com/15007517/44930844-70e7f100-ad14-11e8-9240-99c084f4c736.png">

Closes #1493 