### PR TITLE
Allow query parameters on URLs for cached images

### DIFF
--- a/boilerplate-generator/templates/files/serviceworkerJs.js
+++ b/boilerplate-generator/templates/files/serviceworkerJs.js
@@ -60,7 +60,7 @@ workbox.routing.registerRoute(
 /* uncomment to enable
 // Cache Images
 workbox.routing.registerRoute(
-  /\.(?:png|gif|jpg|jpeg|svg|webp)$/,
+  /\.(?:png|gif|jpg|jpeg|svg|webp)(\?.*)?$/,
   workbox.strategies.cacheFirst({
     cacheName: 'images',
     plugins: [


### PR DESCRIPTION
It seems common for image URLs to have query parameters on them. For example, on https://weston.ruter.net/2018/07/12/wceu-2018-recap-amp-and-pwa/ there is an image:

```html
<img width="2000" height="1200" 
src="https://i0.wp.com/weston.ruter.net/wp-content/uploads/2018/07/DSC00554-2.jpg?resize=2000%2C1200&amp;ssl=1" 
srcset="https://i0.wp.com/weston.ruter.net/wp-content/uploads/2018/07/DSC00554-2.jpg?zoom=2&amp;resize=2000%2C1200&amp;ssl=1 4000w, https://i0.wp.com/weston.ruter.net/wp-content/uploads/2018/07/DSC00554-2.jpg?zoom=3&amp;resize=2000%2C1200&amp;ssl=1 6000w" sizes="100vw" 
data-permalink="https://weston.ruter.net/dsc00554-2-2/" data-orig-file="https://i0.wp.com/weston.ruter.net/wp-content/uploads/2018/07/DSC00554-2.jpg?fit=4000%2C2667&amp;ssl=1" data-orig-size="4000,2667" data-comments-opened="1" data-image-title="DSC00554-2" data-image-description="" data-medium-file="https://i0.wp.com/weston.ruter.net/wp-content/uploads/2018/07/DSC00554-2.jpg?fit=300%2C200&amp;ssl=1" data-large-file="https://i0.wp.com/weston.ruter.net/wp-content/uploads/2018/07/DSC00554-2.jpg?fit=525%2C350&amp;ssl=1">
```

All of the images all have query parameters added to them. In this case, the URLs are generated by [Jetpack Photon Image CDN](https://jetpack.com/support/image-cdn/), a popular plugin in the WordPress ecosystem.

Is there a reason for not including images with query parameters? Perhaps to avoid caching URLs with `RANDOM` query params intended for cache busting? And in this case, is the intention that URLs with query params be whitelisted?