### PR TITLE
Remove experimental flag for amp-image-slider

### DIFF
--- a/src/20_Components/amp-image-slider.html
+++ b/src/20_Components/amp-image-slider.html
@@ -1,6 +1,3 @@
-<!---{
-  "experiments": ["amp-image-slider"]
-}--->
 <!--
   ## Introduction
 


### PR DESCRIPTION
`amp-image-slider` is no longer experimental and will be released soon