### PR TITLE
Remove <amp-install-serviceworker> from <amp-story>

### DIFF
--- a/templates/preview.html
+++ b/templates/preview.html
@@ -51,8 +51,8 @@
     {{^document.isAmpStory}}
     {{> analytics.html}}
     {{> consent.html}}
+    {{> serviceworker.html}}
     {{/document.isAmpStory}}
 
-    {{> serviceworker.html}}
   </body>
 </html>


### PR DESCRIPTION
There's currently no way to use `<amp-install-serviceworker>` in conjunction with `<amp-story>`, see https://github.com/ampproject/amphtml/issues/18172.