### PR TITLE
Remove "us" for GDPR

### DIFF
--- a/templates/consent.html
+++ b/templates/consent.html
@@ -4,7 +4,7 @@
   <script type="application/json">
     {
       "ISOCountryGroups": {
-        "eu": ["at", "be", "bg", "ch", "cy", "cz", "dk", "de", "ee", "el", "es", "fi", "fr", "hr", "ie", "is", "it", "li", "lv", "lt", "lu", "hu", "mt", "nl", "no", "pl", "pt", "ro", "si", "sk", "se", "uk", "us"]
+        "eu": ["at", "be", "bg", "ch", "cy", "cz", "dk", "de", "ee", "el", "es", "fi", "fr", "hr", "ie", "is", "it", "li", "lv", "lt", "lu", "hu", "mt", "nl", "no", "pl", "pt", "ro", "si", "sk", "se", "uk"]
       }
     }
   </script>


### PR DESCRIPTION
@sebastianbenz , sorry, this got left in from debugging. I kept removing "us" when I committed, but, apparently, at some point, I left it in 🙄

Now, with rebase!