### PR TITLE
Remove video dock experiment

### DIFF
--- a/src/30_Advanced/Advanced_Video_Docking.html
+++ b/src/30_Advanced/Advanced_Video_Docking.html
@@ -1,5 +1,4 @@
 <!---{
-  "experiments": ["video-dock"],
   "hidePreview": true,
   "preview": "default"
 }--->


### PR DESCRIPTION
@alanorozco I cannot find the experiment for video dock in the  experiment page, I suppose this is not in experiment anymore?