### PR TITLE
Updated dimensions to account for recent devices

### DIFF
--- a/playground/src/preview/dimensions.json
+++ b/playground/src/preview/dimensions.json
@@ -50,29 +50,39 @@
       "selected": true
     },
     {
-      "label": "iPhone 5",
+      "label": "iPhone 5/SE",
       "width": "320px",
       "height": "568px"
     },
     {
-      "label": "iPhone 7",
+      "label": "iPhone 6/7/8",
       "width": "375px",
       "height": "667px"
     },
     {
-      "label": "iPhone 7 Plus",
+      "label": "iPhone 6/7/8 Plus",
       "width": "414px",
       "height": "736px"
     },
     {
-      "label": "Nexus 5",
-      "width": "360px",
-      "height": "598px"
+      "label": "iPhone X/Xs",
+      "width": "375px",
+      "height": "812px"
     },
     {
-      "label": "Nexus 5X / 6p",
-      "width": "412px",
-      "height": "732px"
+      "label": "iPhone Xs Max",
+      "width": "414px",
+      "height": "896px"
+    },
+    {
+      "label": "Pixel 2",
+      "width": "411px",
+      "height": "731px"
+    },
+    {
+      "label": "Pixel 2 XL",
+      "width": "411px",
+      "height": "823px"
     },
     {
       "label": "Responsive",


### PR DESCRIPTION
The viewer should now account for some of the latest devices, at the moment this just uses Apple and Google phones. I didn't add the iPhone XR or Pixel 3 devices, but they could probably be added as well quite easily. To create this I used Google Chrome Dev Tools as inspiration, and verified a few sizes with https://www.paintcodeapp.com/news/ultimate-guide-to-iphone-resolutions.