### PR TITLE
Allow button to work after lightbox is closed

### DIFF
--- a/src/20_Components/amp-bind.html
+++ b/src/20_Components/amp-bind.html
@@ -281,7 +281,7 @@
     <div>
       <amp-lightbox id="my-lightbox" [open]="showLightbox" layout="nodisplay">
         <div class="lightbox"
-        on="lightboxClose: AMP.setState({showLightbox: false}); tap:my-lightbox.close" role="button" tabindex="0">
+        on="tap:AMP.setState({showLightbox: false})" role="button" tabindex="0">
           <h1>Hello World!</h1>
         </div>
       </amp-lightbox>


### PR DESCRIPTION
Users were unable to open the lightbox a second time after closing the
initial lightbox. This happened because showLightbox was not being set to
false.

* Set state to change showLightbox to false when the user closes the lightbox