### PR TITLE
Remove amp-google-document-embed experiment notification

### DIFF
--- a/src/20_Components/amp-google-document-embed.html
+++ b/src/20_Components/amp-google-document-embed.html
@@ -1,5 +1,4 @@
 <!---{
-    "experiments": ["amp-google-document-embed"],
     "preview": "default"
 }--->
 <!--


### PR DESCRIPTION
It looks like this was left over from when the experiment was removed from the component.