### PR TITLE
Add SXG support to ABE

### DIFF
--- a/backend/config.go
+++ b/backend/config.go
@@ -23,4 +23,6 @@ const (
 	CATEGORY_ADVANCED         = "advanced"
 	CATEGORY_COMPONENTS       = "components"
 	CATEGORY_SAMPLE_TEMPLATES = "samples_templates"
+	// Where to find the SXG service (i.e. host running https://github.com/ampproject/amppackager)
+	PACKAGER_PREFIX = "https://amp-by-example-sxg.appspot.com/"
 )

--- a/backend/packager.go
+++ b/backend/packager.go
@@ -1,0 +1,46 @@
+// Copyright Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backend
+
+import (
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+
+	"google.golang.org/appengine"
+	"google.golang.org/appengine/urlfetch"
+)
+
+func InitPackager() {
+	http.HandleFunc("/amppkg/", func(w http.ResponseWriter, r *http.Request) {
+		u, err := url.Parse(PACKAGER_PREFIX)
+		if err != nil {
+			log.Fatal(err)
+		}
+		p := httputil.NewSingleHostReverseProxy(u)
+		// Need to fiddle with Transport; on GAE this needs to change on every
+		// request. Might not be necessary under Go 1.11:
+		// https://cloud.google.com/blog/products/application-development/go-1-11-is-now-available-on-app-engine
+		p.Transport = &urlfetch.Transport{
+			Context: appengine.NewContext(r),
+		}
+		log.Printf("Proxying request for [%s] to [%s]", r.URL.String(), PACKAGER_PREFIX)
+		p.ServeHTTP(w, r)
+	})
+	// Blocking /priv/doc is one of the "productionizing" steps:
+	// https://github.com/ampproject/amppackager#productionizing
+	http.HandleFunc("/priv/doc", http.NotFound)
+}

--- a/backend/request.go
+++ b/backend/request.go
@@ -86,6 +86,15 @@ func GetHost(r *http.Request) string {
 	return "https://" + r.Host
 }
 
+func SetVary(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h.ServeHTTP(w, r)
+		canonical(w.Header(), "vary")
+		add(w.Header(), "vary", "Accept")
+		add(w.Header(), "vary", "AMP-Cache-Transform")
+	})
+}
+
 func SetContentTypeJson(w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "application/json")
 }
@@ -143,4 +152,47 @@ func onlyPost(next http.HandlerFunc) http.HandlerFunc {
 		}
 		next.ServeHTTP(w, r)
 	}
+}
+
+// Converts header entries associated with key to canonical form. In particular,
+// multiple headers are collapsed into one.
+func canonical(h http.Header, key string) {
+	v := h[http.CanonicalHeaderKey(key)]
+	var a []string
+	for _, vv := range v {
+		if vv != "" {
+			a = append(a, stringMap(strings.Split(vv, ","), strings.TrimSpace)...)
+		}
+	}
+	if len(a) != 0 {
+		h[http.CanonicalHeaderKey(key)] = []string{strings.Join(a, ", ")}
+	}
+}
+
+// Adds value associated with header if not already present. Assumes keys are
+// unique.
+func add(h http.Header, key string, value string) {
+	v := h[http.CanonicalHeaderKey(key)]
+	if len(v) == 0 {
+		h[http.CanonicalHeaderKey(key)] = []string{value}
+	} else {
+		a := stringMap(strings.Split(v[0], ","), strings.TrimSpace)
+		for _, vv := range a {
+			if vv == value {
+				return
+			}
+		}
+		h[http.CanonicalHeaderKey(key)] = []string{strings.Join(append(a, value), ", ")}
+	}
+}
+
+// stringMap returns a new slice containing the results of applying the function f to
+// each string in the original slice. From
+// https://gobyexample.com/collection-functions
+func stringMap(vs []string, f func(string) string) []string {
+	vsm := make([]string, len(vs))
+	for i, v := range vs {
+		vsm[i] = f(v)
+	}
+	return vsm
 }

--- a/packager/Dockerfile
+++ b/packager/Dockerfile
@@ -1,0 +1,37 @@
+# Maybe switch to one of the Google-provided images? But seems to be go 1.8, not 1.10:
+# https://cloud.google.com/appengine/docs/flexible/custom-runtimes/build#base
+FROM golang:1.10
+
+ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64 /usr/local/bin/dumb-init
+RUN chmod +x /usr/local/bin/dumb-init
+ENTRYPOINT ["dumb-init", "--"]
+
+RUN groupadd -r amppkg && useradd --no-log-init -r -g amppkg amppkg
+WORKDIR /amppkg
+
+COPY amppkg.toml /amppkg
+COPY dist /www
+# Copy whatever certs are available in the certs/ directory (both encrypted and
+# unencrypted) into the container. (./decrypt.sh will NOOP if any *.pem exist.)
+COPY certs/*pem* /amppkg/
+COPY decrypt.sh /amppkg
+# Need an easy way to generate this diff? Use the GitHub API--example of a diff
+# between ampproject/amppackager:master and a fork at
+# ithinkihaveacat/ampproject:abe:
+# https://github.com/ampproject/amppackager/compare/master...ithinkihaveacat:abe.diff
+COPY amppackager.diff /amppkg
+RUN chmod +x /amppkg/decrypt.sh
+RUN chown -R amppkg:amppkg /amppkg
+
+# Because it's not possible to directly install a fork of a package via "go get"
+# (see https://blog.sgmansfield.com/2016/06/working-with-forks-in-go/), we
+# instead download the upstream, apply the appropriate patch, and then install
+# the patched version.
+RUN go get -d -u github.com/ampproject/amppackager/cmd/amppkg
+# See above for how to instructions on how to generate the diff
+RUN git -C $GOPATH/src/github.com/ampproject/amppackager apply < /amppkg/amppackager.diff
+RUN go install github.com/ampproject/amppackager/cmd/amppkg
+
+USER amppkg
+EXPOSE 8080
+CMD [ "bash", "-c", "./decrypt.sh && exec amppkg -config /amppkg/amppkg.toml" ]

--- a/packager/README.md
+++ b/packager/README.md
@@ -1,0 +1,57 @@
+## Assumptions
+
+- *You're packaging (i.e. want to create SXG for) `ampbyexample.com` (this exact
+  domain)*, and the appropriate certificates are in the `certs/` directory.
+- *You're deploying to the Google Cloud project `amp-by-example-sxg`*, and the
+  password to decrypt the key will be available via [project-wide custom
+  metadata](https://cloud.google.com/compute/docs/storing-retrieving-metadata#projectwide)
+  at
+  http://metadata.google.internal/computeMetadata/v1/project/attributes/password
+  (see `decrypt.sh`).
+
+If either of these is not true, you will need to make changes to make the
+correct certificate available, and to ensure the unencrypted certificates make
+it onto the container. Please see `Dockerfile` and `decrypt.sh`, and the sample
+command for encryption and decription at the bottom of this file. It may also be
+useful to be aware of how to pass environment variables to Docker via the
+`--env` command.
+
+## Deploy and run on Google App Engine
+
+```sh
+# generate "dist" directory (contains valid AMP)
+$ npx gulp --gulpfile ../gulpfile.js build:sxg
+
+# deploy
+gcloud app deploy --project=amp-by-example-sxg
+```
+
+## Build and run on local Docker instance
+
+```sh
+# generate "dist" directory (contains valid AMP)
+$ npx gulp --gulpfile ../gulpfile.js build:sxg
+
+# build local Docker image called "amppkg"
+$ docker build -t amppkg .
+
+# create local container from Docker image, expose ports (uses CMD)
+$ docker run -p 8080:8080 --env PASSWORD=$PASSWORD amppkg
+
+# create (local) container from Docker image and provide shell (ignore CMD)
+$ docker run -it amppkg bash
+```
+
+## Misc
+
+Encrypt file:
+
+```sh
+openssl aes-256-cbc -md md5 -e -k $PASSWORD -in plain.pem -out encrypted.pem.enc
+```
+
+Decrypt file:
+
+```sh
+openssl aes-256-cbc -md md5 -d -k $PASSWORD -in encrypted.pem.enc -out plain.pem
+```

--- a/packager/amppackager.diff
+++ b/packager/amppackager.diff
@@ -1,0 +1,170 @@
+diff --git a/amppkg.example.toml b/amppkg.example.toml
+index 3ce5719..fd5ba1f 100644
+--- a/amppkg.example.toml
++++ b/amppkg.example.toml
+@@ -56,6 +56,14 @@ KeyFile = './pems/privkey.pem'
+ # file, it should support shared/exclusive locking.
+ OCSPCache = '/tmp/amppkg-ocsp'
+ 
++# If a Docroot directory is specified, amppkg will look in this directory for
++# valid AMPs to package (instead of fetching AMPs from the network).
++# Docroot = "/www"
++
++# If a ProjectId is specified, amppkg will verify that all incoming HTTP
++# requests have an X-Appengine-Inbound-Appid header equal to this value.
++# ProjectId = "ampbyexample"
++
+ # This is a simple level of validation, to guard against accidental
+ # misconfiguration of the reverse proxy that sits in front of the packager.
+ #
+diff --git a/cmd/amppkg/main.go b/cmd/amppkg/main.go
+index 71048c1..4c63640 100644
+--- a/cmd/amppkg/main.go
++++ b/cmd/amppkg/main.go
+@@ -25,17 +25,17 @@ import (
+ 	"net/http"
+ 	"net/url"
+ 	"path"
++	"strings"
+ 	"time"
+ 
+ 	"github.com/WICG/webpackage/go/signedexchange"
+-	"github.com/julienschmidt/httprouter"
+-	"github.com/pkg/errors"
+-
+ 	"github.com/ampproject/amppackager/packager/certcache"
++	"github.com/ampproject/amppackager/packager/rtv"
+ 	"github.com/ampproject/amppackager/packager/signer"
+ 	"github.com/ampproject/amppackager/packager/util"
+ 	"github.com/ampproject/amppackager/packager/validitymap"
+-	"github.com/ampproject/amppackager/packager/rtv"
++	"github.com/julienschmidt/httprouter"
++	"github.com/pkg/errors"
+ )
+ 
+ var flagConfig = flag.String("config", "amppkg.toml", "Path to the config toml file.")
+@@ -56,6 +56,24 @@ func (this logIntercept) ServeHTTP(resp http.ResponseWriter, req *http.Request)
+ 	// TODO(twifkak): Separate the typical weblog from the detailed error log.
+ }
+ 
++func allowProject(id string, h http.Handler) http.Handler {
++	return http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
++		// X-Appengine-Inbound-Appid can be trusted on GAE:
++		// https://cloud.google.com/appengine/docs/standard/go/appidentity/#asserting_identity_to_other_app_engine_apps
++		if req.Header.Get("X-Appengine-Inbound-Appid") == id {
++			log.Printf("Allowing GET from [%s]", req.Header.Get("X-Appengine-Inbound-Appid"))
++			h.ServeHTTP(resp, req)
++		} else {
++			log.Printf(
++				"Denying GET from [%s], expected X-Appengine-Inbound-Appid header to be [%s]\n",
++				req.Header.Get("X-Appengine-Inbound-Appid"),
++				id,
++			)
++			http.Error(resp, "403 Forbidden", http.StatusForbidden)
++		}
++	})
++}
++
+ // Exposes an HTTP server. Don't run this on the open internet, for at least two reasons:
+ //  - It exposes an API that allows people to sign any URL as any other URL.
+ //  - It is in cleartext.
+@@ -128,8 +146,8 @@ func main() {
+ 		}
+ 	}
+ 
+-	packager, err := signer.New(certs[0], key, config.URLSet, rtvCache, certCache.IsHealthy,
+-		overrideBaseURL, /*requireHeaders=*/!*flagDevelopment)
++	packager, err := signer.New(certs[0], key, config.Docroot, config.URLSet, rtvCache, certCache.IsHealthy,
++		overrideBaseURL /*requireHeaders=*/, !*flagDevelopment)
+ 	if err != nil {
+ 		die(errors.Wrap(err, "building packager"))
+ 	}
+@@ -147,11 +165,16 @@ func main() {
+ 		addr = "localhost"
+ 	}
+ 	addr += fmt.Sprint(":", config.Port)
++	handler := http.Handler(logIntercept{mux})
++	if config.ProjectId != "" {
++		handler = allowProject(config.ProjectId, handler)
++	}
+ 	server := http.Server{
+ 		Addr: addr,
+ 		// Don't use DefaultServeMux, per
+ 		// https://blog.cloudflare.com/exposing-go-on-the-internet/.
+-		Handler:           logIntercept{mux},
++		// TODO Respond to /_ah/healthcheck with a 200 (consider certCache.IsHealthy, too)
++		Handler:           handler,
+ 		ReadTimeout:       10 * time.Second,
+ 		ReadHeaderTimeout: 5 * time.Second,
+ 		// If needing to stream the response, disable WriteTimeout and
+@@ -165,7 +188,11 @@ func main() {
+ 
+ 	// TODO(twifkak): Add monitoring (e.g. per the above Cloudflare blog).
+ 
+-	log.Println("Serving on port", config.Port)
++	var d []string
++	for i := range config.URLSet {
++		d = append(d, config.URLSet[i].Sign.Domain)
++	}
++	log.Printf("Serving SXG of \"%s\" on port %d\n", strings.Join(d, ", "), config.Port)
+ 
+ 	// TCP keep-alive timeout on ListenAndServe is 3 minutes. To shorten,
+ 	// follow the above Cloudflare blog.
+diff --git a/packager/certcache/certcache.go b/packager/certcache/certcache.go
+index f07b931..b4cd645 100644
+--- a/packager/certcache/certcache.go
++++ b/packager/certcache/certcache.go
+@@ -422,7 +422,7 @@ func (this *CertCache) fetchOCSP(orig []byte, ocspUpdateAfter *time.Time) []byte
+ 	// OCSP duration must be <=7 days, per
+ 	// https://wicg.github.io/webpackage/draft-yasskin-httpbis-origin-signed-exchanges-impl.html#cross-origin-trust.
+ 	// Serving these responses may cause UAs to reject the SXG.
+-	if resp.NextUpdate.Sub(resp.ThisUpdate) > time.Hour * 24 * 7 {
++	if resp.NextUpdate.Sub(resp.ThisUpdate) > time.Hour*24*7 {
+ 		log.Printf("OCSP nextUpdate %+v too far ahead of thisUpdate %+v\n", resp.NextUpdate, resp.ThisUpdate)
+ 		return orig
+ 	}
+diff --git a/packager/signer/signer.go b/packager/signer/signer.go
+index 0b8348d..cd6f1e7 100644
+--- a/packager/signer/signer.go
++++ b/packager/signer/signer.go
+@@ -128,13 +128,25 @@ func noRedirects(req *http.Request, via []*http.Request) error {
+ 	return http.ErrUseLastResponse
+ }
+ 
+-func New(cert *x509.Certificate, key crypto.PrivateKey, urlSets []util.URLSet,
++func New(cert *x509.Certificate, key crypto.PrivateKey, docroot string, urlSets []util.URLSet,
+ 	rtvCache *rtv.RTVCache, shouldPackage func() bool, overrideBaseURL *url.URL,
+ 	requireHeaders bool) (*Signer, error) {
++	var t http.RoundTripper
++	if docroot != "" {
++		t := &http.Transport{}
++		r := http.NewFileTransport(http.Dir(docroot))
++		t.RegisterProtocol("http", r)
++		t.RegisterProtocol("https", r)
++		log.Printf("AMP source is \"%s\"", docroot)
++	} else {
++		t = http.DefaultTransport
++		log.Printf("AMP source is network")
++	}
+ 	client := http.Client{
+ 		CheckRedirect: noRedirects,
+ 		// TODO(twifkak): Load-test and see if default transport settings are okay.
+-		Timeout: 60 * time.Second,
++		Timeout:   60 * time.Second,
++		Transport: t,
+ 	}
+ 
+ 	return &Signer{cert, key, &client, urlSets, rtvCache, shouldPackage, overrideBaseURL, requireHeaders}, nil
+diff --git a/packager/util/config.go b/packager/util/config.go
+index 8311812..0b5e25a 100644
+--- a/packager/util/config.go
++++ b/packager/util/config.go
+@@ -29,6 +29,8 @@ type Config struct {
+ 	CertFile  string // This must be the full certificate chain.
+ 	KeyFile   string // Just for the first cert, obviously.
+ 	OCSPCache string
++	Docroot   string
++	ProjectId string
+ 	URLSet    []URLSet
+ }
+ 

--- a/packager/amppkg.toml
+++ b/packager/amppkg.toml
@@ -1,0 +1,147 @@
+# This is a TOML 0.4.0 file, as specified by https://github.com/toml-lang/toml.
+
+# The port to listen on; 8080 is the default.
+# Port = 8080
+
+# Uncomment this line to serve only to localhost clients, e.g. for testing, by
+# binding on the loopback interface.
+# LocalOnly = true
+
+# The path to the PEM file containing the full certificate chain, ordered from
+# leaf to root.
+#
+# Typically, it would look like:
+#   -----BEGIN CERTIFICATE-----
+#   ....
+#   -----END CERTIFICATE-----
+#   -----BEGIN CERTIFICATE-----
+#   ....
+#   -----END CERTIFICATE-----
+# where the first certificate is for your domain, and the second is your CA's
+# cert.
+#
+# To verify it has the right key type:
+#   openssl x509 -in cert.pem -text | grep 'ASN1 OID: prime256v1'
+# To verify it has the CanSignHttpExchanges extension:
+#   openssl x509 -in cert.pem -text | grep 1.3.6.1.4.1.11129.2.1.22:
+#
+# This will be served at /amppkg/cert/blahblahblah, where "blahblahblah" is a
+# stable unique identifier for the cert (currently, its base64-encoded
+# SHA-256).
+#
+# The leaf certificate must use an EC P-256 key. (See https://goo.gl/pwK9EJ
+# item 3.1.5.) It must have at least one SCT, either as an X.509 extension or
+# as an extension to the OCSP responses from the URI mentioned in its Authority
+# Information Access extension. (See https://goo.gl/JQiyNs item 7.4.)
+#
+# To mitigate the risk of an attacker gaining access to your private key
+# through a vulnerability in this packager, you should generate a new
+# certificate/key pair for the domain(s) you wish to sign packages with. This
+# allows you to revoke that certificate without affecting your normal
+# web-serving traffic.
+CertFile = '/amppkg/cert.pem'
+
+# The path to the PEM file containing the private key that corresponds to the
+# leaf certificate in CertFile.
+KeyFile = '/amppkg/privkey.pem'
+
+# The path to a file where the OCSP response will be cached. The parent
+# directory should exist, but the file need not. If this is a network-mounted
+# file, it should support shared/exclusive locking.
+OCSPCache = '/tmp/ocsp'
+
+Docroot = '/www'
+
+# Project Id of the Google Cloud Project from which requests will be made. This
+# will probably be the project corresponding to NEW_ADDRESS in request.go.
+ProjectId = 'amp-by-example'
+
+# This is a simple level of validation, to guard against accidental
+# misconfiguration of the reverse proxy that sits in front of the packager.
+#
+# You must specify at least one URLSet; you may specify multiple. Each one must
+# specify a Sign pattern and may specify a Fetch pattern. When the packager
+# receives a request for a package, it will first validate that the requested
+# fetch/sign URL pair matches at least one of the given URLSets.
+[[URLSet]]
+  # What URLs are allowed to show up in the browser's URL bar, when served from
+  # the AMP Cache. By default, the URL that the frontend requests to sign is
+  # also the URL where the packager fetches it. For extra flexibility, see
+  # URLSet.Fetch below.
+  [URLSet.Sign]
+    # The scheme of the URL must be https. There is no way to configure this.
+    # The `user:pass@` portion is disallowed. There is no way to configure this.
+
+    # The domain to limit signed URLs to. An exact string match. The certificate
+    # must cover this domain. This will probably be the domain associated with
+    # NEW_ADDRESS in request.go.
+    Domain = "ampbyexample.com"
+
+    # A full-match regexp on the path (not including the ?query).
+    # Defaults to ".*". The below example allows paths starting with /world/.
+    # PathRE = "/world/.*"
+
+    # A list of full-match regexps, carving out exclusions to the above PathRE.
+    # Examples of paths you might want to exclude:
+    #   * Personalized content, such as user settings pages. Signed exchanges
+    #     are cached globally and served to all users. (Personalization that
+    #     happens at runtime via JS is fine.) This provides defense-in-depth,
+    #     in addition to the Cache-Control: public check.
+    #   * User-generated content, such as forums. For instance, if there's a
+    #     chance of an XSS vulnerability in your templating library, the impact
+    #     of such event is higher here: even after you've fixed the bug, caches
+    #     may serve your signed packages for up to 7 days.
+    # PathExcludeRE = []
+
+    # A full-match regexp on the query portion of the URL, excluding the initial
+    # "?". Defaults to ".*". The below example disallows non-empty query strings
+    # (though a single "?" is allowed).
+    # QueryRE = ""
+
+    # The fragment portion of the URL (i.e. the '#' and everything after) must
+    # be empty. There is no way to configure this.
+
+    # By default, stateful headers (such as Set-Cookie and WWW-Authenticate)
+    # are stripped from the response before packaging. If instead you wish for
+    # this to cause packaging to fail, set ErrorOnStatefulHeaders = true.
+    # ErrorOnStatefulHeaders = true
+
+  # By default, the packager only looks at the sign param, and fetches the
+  # content from the same location. If you'd like more flexibility (for
+  # instance, to fetch content from an edge node), uncomment this section. This
+  # allows the frontend to specify an additional `fetch` query parameter.
+  # Instead of looking like:
+  #
+  #   /priv/doc/https://example.com/page.html
+  #
+  # The URL will look like:
+  #
+  #   /priv/doc?fetch=https%3A%2F%2Finternal.example.com%2Fpage.html&sign=https%3A%2F%2Fexample.com%2Fpage.html
+  #
+  # Note that this reduces the defense-in-depth against the "signing oracle"
+  # attack. If an attacker can request custom URLs from the packager (or
+  # convince a frontend server to do so), it could convince the packager to
+  # fetch page A and sign it as page B. If enabling this, make sure there is no
+  # unauthorized access to the packager.
+  # [URLSet.Fetch]
+  # # The set of allowed schemes to fetch from is ["https"] by default, but may
+  # # be ["http"] or ["http", "https"].
+  # Scheme = ["http"]
+  #
+  # # By default, the packager enforces that the path and query are the same
+  # # between the fetch and sign URLs (e.g. respond in error if
+  # # fetch=http%3A%2F%2Ffoo%2Fbar.html and
+  # # sign=https%3A%2F%2Fbaz%2Fnot-bar.html). Change SamePath to false if this
+  # # requirement is too stringent.
+  # SamePath = false
+  #
+  # # A full-match regexp on the domain allowed. Only one of DomainRE and
+  # # Domain may be specified. Exercise caution; test the regexp thoroughly.
+  # # For instance, a DomainRE of "www.example.com" would allow fetches from
+  # # www-example.com.
+  # DomainRE = "www\\.corp\\d+\\.example\\.com"
+  #
+  # # All other fields behave the same.
+  # Domain = "www.corp.example.com"
+  # PathRE = "/world/.*"
+  # QueryRE = ""

--- a/packager/app.yaml
+++ b/packager/app.yaml
@@ -1,0 +1,8 @@
+# https://cloud.google.com/appengine/docs/flexible/custom-runtimes/
+runtime: custom
+env: flex
+# https://cloud.google.com/appengine/docs/flexible/custom-runtimes/configuring-your-app-with-app-yaml#manual-scaling
+manual_scaling:
+  # Only start one instance so the OCSPCache is shared, see
+  # https://github.com/ampproject/amppackager#redundancy
+  instances: 1

--- a/packager/decrypt.sh
+++ b/packager/decrypt.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+if [[ -e /amppkg/privkey.pem && -e /amppkg/cert.pem ]]; then
+  echo "info: /amppkg/{privkey,cert}.pem already exist, not decrypting"
+  exit 0
+fi
+
+if [[ -z $PASSWORD ]]; then
+  # To set the password, see https://cloud.google.com/compute/docs/storing-retrieving-metadata?hl=en_US#projectwide
+  # Re security, see https://cloud.google.com/compute/docs/storing-retrieving-metadata#is_metadata_information_secure
+  PASSWORD=$(curl -Ss -H 'Metadata-Flavor: Google' http://metadata.google.internal/computeMetadata/v1/project/attributes/password)
+  if [[ $? -ne 0 ]]; then
+    echo "error: can't retrieve PASSWORD from metadata store, can't decrypt keys"
+    exit 1
+  fi
+fi
+
+# Why -md md5? https://www.openssl.org/docs/faq.html#USER3
+openssl aes-256-cbc -d -md md5 -k "$PASSWORD" -in /amppkg/privkey.pem.enc -out /amppkg/privkey.pem
+
+if [[ $? -ne 0 ]]; then
+  echo "error: can't decrypt /amppkg/privkey.pem.enc (wrong password?)"
+  exit 1
+fi
+
+openssl aes-256-cbc -d -md md5 -k "$PASSWORD" -in /amppkg/cert.pem.enc -out /amppkg/cert.pem
+
+if [[ $? -ne 0 ]]; then
+  echo "error: can't decrypt /amppkg/cert.pem.enc (wrong password?)"
+  exit 1
+fi

--- a/server.go
+++ b/server.go
@@ -41,6 +41,7 @@ func init() {
 	backend.InitCheckout()
 	backend.InitAmpConsent()
 	backend.InitAmpStoryAutoAds()
+	backend.InitPackager()
 	backend.InitSeatmapPage()
 	backend.InitOAuth()
 	backend.InitStateRefreshSection()


### PR DESCRIPTION
This PR contains two things required for ampbyexample.com to support signed-exchange (SXG). This will ultimately enable ABE content to appear in the Google Search and similar under the ampbyexample.com URL ([more info](https://wicg.github.io/webpackage/draft-yasskin-webpackage-use-cases.html#private-prefetch)).

1. It modifies the front-end to proxy requests with an `Accept` header of `application/signed-exchange`  to `https://abe-packager.appspot.com/`, which is a separate GCP node running https://github.com/ampproject/amppackager which returns "signed" versions of ABE's valid AMP resources.
2. Contains the Dockerfile and related scripts and configuration to build and deploy `https://abe-packager.appspot.com/`.

The algorithm this code is intending to follow with respect to what requests are proxied to amppackager is:

1. If the URL starts with `/amppkg/`, forward the request unmodified.
2. If the URL points to an AMP page and the `AMP-Cache-Transform` request
        header is present, rewrite the URL by prepending `/priv/doc` and forward
        the request.
3. If at all possible, don't forward requests for non-AMP pages; its
       transforms may break non-AMP HTML.
4. DO NOT forward `/priv/doc` requests; these URLs are meant to be
        generated by the frontend server only.

 ([source](https://github.com/ampproject/amppackager#productionizing))

/cc @twifkak 