### PR TITLE
Set headers, and then ServeHTTP()

### DIFF
--- a/backend/request.go
+++ b/backend/request.go
@@ -88,10 +88,10 @@ func GetHost(r *http.Request) string {
 
 func SetVary(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		h.ServeHTTP(w, r)
 		canonical(w.Header(), "vary")
 		add(w.Header(), "vary", "Accept")
 		add(w.Header(), "vary", "AMP-Cache-Transform")
+		h.ServeHTTP(w, r)
 	})
 }
 


### PR DESCRIPTION
It looks like this fixes #1615, although I'm not entirely sure why…

The other approach is to simply ditch the fancy header mangling functions, and just go for

```go
w.Header().Add("vary", "Accept, AMP-Cache-Transform")
```

This may create an additional `Vary` header if one already exists on the request, but it's supposed to be HTTP compliant.