### PR TITLE
Seatmap improvements

### DIFF
--- a/src/30_Advanced/SeatMap.html
+++ b/src/30_Advanced/SeatMap.html
@@ -80,7 +80,7 @@ how to dynamically select and unselect seats.
           margin: auto;
       }
       .seatmap  amp-selector .svg-container {
-        padding: 0 20px 0 20px;
+        padding: 0 24px;
       }
     </style>
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style>

--- a/src/30_Advanced/SeatMap.html
+++ b/src/30_Advanced/SeatMap.html
@@ -79,6 +79,9 @@ how to dynamically select and unselect seats.
           right: 0;
           margin: auto;
       }
+      .seatmap  amp-selector .svg-container {
+        padding: 0 20px 0 20px;
+      }
     </style>
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style>
     <noscript>
@@ -119,17 +122,23 @@ how to dynamically select and unselect seats.
             <amp-selector multiple
                   on="select:AMP.setState({
                       selectedSeats: event.selectedOptions
-                    })">
-              <svg preserveAspectRatio="xMidYMin slice" viewBox="0 0 {{width}} {{height}}">
-              {{#seats}}             
-              option button tabindex class x y   
-                <rect option="{{id}}" role="button" 
-                  tabindex="0" class="seat {{unavailable}}"
-                  x="{{x}}" y="{{y}}" 
-                  width="{{width}}" height="{{height}}" 
-                  rx="{{rx}}" ry="{{ry}}"/> 
-              {{/seats}}
-              </svg>
+                    })" layout="fill">
+              <!--~
+              In order to add a space around the seatmap keeping it as `amp-pan-zoom` space you can wrap the svg into
+              a div and use padding.
+              ~-->
+              <div class="svg-container">
+                <svg preserveAspectRatio="xMidYMin slice" viewBox="0 0 {{width}} {{height}}">
+                {{#seats}}             
+                option button tabindex class x y   
+                  <rect option="{{id}}" role="button" 
+                    tabindex="0" class="seat {{unavailable}}"
+                    x="{{x}}" y="{{y}}" 
+                    width="{{width}}" height="{{height}}" 
+                    rx="{{rx}}" ry="{{ry}}"/> 
+                {{/seats}}
+                </svg>
+              </div>
             </amp-selector>
           </amp-pan-zoom>
         </template>


### PR DESCRIPTION
- add space around the seatmap in which you can still double tap
- fix the point of zooming by adding `layout=fill` to the `amp-selector`

@sebastianbenz the `div` strategy is necessary as explained in the comment as adding a padding directly to the svg interacts with the `amp-pan-zoom` sizing, while just having a margin outside the `amp-pan-zoom` makes the margin not clickable for zooming.

@pbalaram FYI