### PR TITLE
📖amp-ima-video: Add documentation for attributes

### DIFF
--- a/src/20_Components/amp-ima-video.html
+++ b/src/20_Components/amp-ima-video.html
@@ -37,5 +37,31 @@
     <source src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4" type="video/mp4">
   </amp-ima-video>
 
+  <!--
+    Provide a format string in the `data-ad-label` attribute to customize the ad disclosure that is displayed while an ad is playing. This allows users to support ad disclosures in different languages.
+
+    A format string should look like `"Ad (%s of %s)"`.  The `"%s"` in the format string is replaced with the current ad number in the sequence and the total number of ads, respectively (e.g. Ad 2 of 3). If no value is given, this defaults to `"Ad (%s of %s)"`.
+  -->
+  <amp-ima-video id="myVideo2"
+      width="640" height="360" layout="responsive"
+      data-tag="https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/ad_rule_samples&ciu_szs=300x250&ad_rule=1&impl=s&gdfp_req=1&env=vp&output=vmap&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ar%3Dpreonlybumper&cmsid=496&vid=short_onecue&correlator="
+      data-poster="<%host%>/img/ima-poster.jpg"
+      data-ad-label="Publicidad (%s de %s)">
+    <source src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4" type="video/mp4">
+  </amp-ima-video>
+
+  <!--
+    Use the `autoplay` attribute to play video automatically without requiring the user to press "play".
+
+    Optionally, use `data-delay-ad-request="true"` to delay an ad request until either the user scrolls the page, or for 3 seconds, whichever occurs first.  The default behavior of the amp-ima-video component is to request an ad on the AMP page load which has the effect of being counted as 'code served' even if there is no impression.
+  -->
+  <amp-ima-video id="myVideo3"
+      width="640" height="360" layout="responsive"
+      data-tag="https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/ad_rule_samples&ciu_szs=300x250&ad_rule=1&impl=s&gdfp_req=1&env=vp&output=vmap&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ar%3Dpreonlybumper&cmsid=496&vid=short_onecue&correlator="
+      data-src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"
+      data-delay-ad-request="true"
+      autoplay>
+  </amp-ima-video>
+
 </body>
 </html>


### PR DESCRIPTION
Relates to https://github.com/ampproject/amphtml/issues/19393

## Changes

Add documentation for various attributes for the `<amp-ima-video>` element, including:
- `data-ad-label`
- `autoplay`
- `data-delay-ad-request`

## Screenshot

### data-ad-label

<img width="1673" alt="exampledataadlabel" src="https://user-images.githubusercontent.com/4807680/49702259-7080b100-fbb3-11e8-9f6e-5124f660704e.png">

### autoplay + data-delay-ad-request

<img width="1671" alt="exampleautoplay" src="https://user-images.githubusercontent.com/4807680/49702254-62329500-fbb3-11e8-88e3-90efd6b0b2f4.png">
