### PR TITLE
Fix build perf

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -338,6 +338,9 @@ gulp.task('validate:example', () => {
 });
 
 function shouldMinifyHtml(file) {
+  if (config.env !== PROD) {
+    return false;
+  }
   if (!file.path.endsWith('.html')) {
     return false;
   }
@@ -614,3 +617,4 @@ function run(command) {
 function isFixed(file) {
   return file.eslint.fixed;
 }
+


### PR DESCRIPTION
Disable HTML minification during development build. This makes
compile:example run > 10x as fast.