### PR TITLE
Update amp-video-docking example

### DIFF
--- a/src/30_Advanced/Advanced_Video_Docking.html
+++ b/src/30_Advanced/Advanced_Video_Docking.html
@@ -271,8 +271,8 @@ preview: default
       animation on `undock`.
 
       Note that we're seeting the action on the slot element. If we were to set
-      it in the video itself, it would be triggered for minimize-to-corner rather
-      than minimize-to-slot. -->
+      it in the video itself, it would be triggered for `minimize-to-corner` rather
+      than `minimize-to-slot`. -->
       <amp-layout
           layout="responsive"
           width="16"


### PR DESCRIPTION
- Docking is now a separate extension.
- Action is now either triggered from video or from slot depending on target.

/cc @aghassemi 