### PR TITLE
Fix amp-carousel arbitrary elements example

### DIFF
--- a/src/20_Components/amp-carousel.html
+++ b/src/20_Components/amp-carousel.html
@@ -80,16 +80,19 @@
   <!-- Each of these nodes may also have arbitrary HTML children.  -->
   <amp-carousel height="300" layout="fixed-height" type="slides">
     <div>
-      <div class="blue-box"></div>
-      This is a blue box.
+      <div class="blue-box">
+        This is a blue box.
+      </div>
     </div>
     <div>
-      <div class="red-box"></div>
-      This is a red box.
+      <div class="red-box">
+        This is a red box.
+      </div>
     </div>
     <div>
-      <div class="green-box"></div>
-      This is a green box.
+      <div class="green-box">
+        This is a green box.
+      </div>
     </div>
   </amp-carousel>
   <!-- A good use case for `amp-carousel` are image galleries, [here](/advanced/image_galleries_with_amp-carousel/) are some examples. -->


### PR DESCRIPTION
Puts content inside of the div tags to have the carousel slides render correctly