### PR TITLE
🐛Fix joining analytics example

### DIFF
--- a/static/linker/demo-page.html
+++ b/static/linker/demo-page.html
@@ -33,7 +33,8 @@
         {
           "linkers": {
             "enabled": true,
-            "proxyOnly": false
+            "proxyOnly": false,
+            "destinationDomains": ["ampbyexample.com"]
           }
         }
       </script>


### PR DESCRIPTION
We introduced logic into linker amproject/amphtml#19520 to not decorate links to the same domain unless specifically enabled. That feature broke this example. This PR specifically enables the ABE domain to be decorated.