### PR TITLE
Migrating Cart from CLIENT_ID to sessions + "Remove Items from Cart" functionality.

### DIFF
--- a/src/60_Samples_%26_Templates/Product_Page.html
+++ b/src/60_Samples_%26_Templates/Product_Page.html
@@ -691,19 +691,23 @@ This sample showcases how to build a product page in AMP HTML.
         <span [text]="product[product.selectedColor].sizes[product.selectedSize]">$5.99</span>
     </p>
 
-    <!-- ## Product page -->
+    <!-- ## Add To Cart -->
     <!-- The add-to-cart action action is implemented using  [amp-form](/components/amp-form/). In our sample we use the [amp-selector](/components/amp-selector/) for selecting different product properties.
-    Pressing the `ADD TO CART` button adds the product to a shopping cart page using the properties you have selected. Notice that the button URL contains the query `clientId={{ClientId}}`.
-    If an item is successfully added to the shopping cart, we redirect the user to the shopping cart page.
-    The redirect target is configured via a header in the server's form response ([redirecting after submission](https://github.com/ampproject/amphtml/blob/master/extensions/amp-form/amp-form.md#redirecting-after-a-submission)):
 
-      access-control-expose-headers:AMP-Access-Control-Allow-Source-Origin,AMP-Redirect-To
-      amp-redirect-to:http://ampbyexample.com/shopping_cart/?clientid=amp-123456789 -->
+    Pressing the `ADD TO CART` button triggers an `XHR POST` request to `/add_to_cart`. Here, we need to distinguish two scenarios:
 
-    <!-- We use the `CLIENT_ID` variable to identify the user, this enables storing a shopping cart between repeated visits of an AMP page (either via the AMP Cache or the original host). This variable can be used inside an amp-form by declaring an hidden input value with `default-value="CLIENT_ID(cart)`. Read more about variable substitution [here](https://github.com/ampproject/amphtml/blob/master/spec/amp-var-substitutions.md). -->
+    - If the user is visiting the cached version of the page, the server receives the request on the `POST` handler and redirects again to `/add_to_cart`, but transforming the initial request, into `GET`, using the `AMP-Redirect-To` header (see [redirecting after submission](https://github.com/ampproject/amphtml/blob/master/extensions/amp-form/amp-form.md#redirecting-after-a-submission)). Next, the `GET` handler adds the item to the session, and redirects to the final destination: the `/shopping_cart` page.
+    - If the user is visiting the page from its origin, there's no need for a 'double redirect', since the server can access the session directly on the `POST` handler, then add the item to the cart, and, finally redirect to the `/shopping_cart` page.
+     -->
+
+     <!-- 
+      The first step of the previous list is necessary, in order to move the user outside the domain of the cache (where the session can't be accessed on browsers that block third party cookies), into an intermediate step in the origin (where the session cookie, is a first party cookie).
+
+      That way, we can maintain user state across origins, in a secure way, while being compatible with all the major browsers.
+     -->
 
       <form id="order" method="POST"
-            action-xhr="/samples_templates/product_page/add_to_cart"
+            action-xhr="https://abe-cart-service.glitch.me/add_to_cart"
             target="_top" class="order margin1">
         <div class="color-selector">
           <label for="color">Color:</label>
@@ -770,7 +774,6 @@ This sample showcases how to build a product page in AMP HTML.
         </div>
         <input type="hidden" name="name" value="Apple">
         <input type="hidden" name="price" value="$1.99">
-        <input name="clientId" type="hidden" value="CLIENT_ID(cart)" data-amp-replace="CLIENT_ID">
         <div submit-error>
           <template type="amp-mustache">
             Error! Looks like something went wrong with your shopping cart, please try to add an item again. {{error}}

--- a/src/60_Samples_%26_Templates/Product_Page.html
+++ b/src/60_Samples_%26_Templates/Product_Page.html
@@ -652,7 +652,8 @@ This sample showcases how to build a product page in AMP HTML.
           "M": "$5.99",
           "L": "unavailable"
         },
-        "defaultSize": "S"
+        "defaultSize": "S",
+        "id": 1
       },
       "golden": {
         "sizes": {
@@ -660,7 +661,8 @@ This sample showcases how to build a product page in AMP HTML.
           "M": "unavailable",
           "L": "$9.99"
         },
-        "defaultSize": "L"
+        "defaultSize": "L",
+        "id": 2
       },
       "red": {
         "sizes": {
@@ -668,7 +670,8 @@ This sample showcases how to build a product page in AMP HTML.
           "M": "$7.99",
           "L": "$7.99"
         },
-        "defaultSize": "M"
+        "defaultSize": "M",
+        "id": 3
       }
     }
     </script>
@@ -696,15 +699,15 @@ This sample showcases how to build a product page in AMP HTML.
 
     Pressing the `ADD TO CART` button triggers an `XHR POST` request to `/add_to_cart`. Here, we need to distinguish two scenarios:
 
-    - If the user is visiting the cached version of the page, the server receives the request on the `POST` handler and redirects again to `/add_to_cart`, but transforming the initial request, into `GET`, using the `AMP-Redirect-To` header (see [redirecting after submission](https://github.com/ampproject/amphtml/blob/master/extensions/amp-form/amp-form.md#redirecting-after-a-submission)). Next, the `GET` handler adds the item to the session, and redirects to the final destination: the `/shopping_cart` page.
+    - If the user is visiting the cached version of the page, the server receives the request on the `POST` handler and redirects again to `/add_to_cart` on the non-cache origin, but transforming the initial request, into `GET`, using the `AMP-Redirect-To` header (see [redirecting after submission](https://github.com/ampproject/amphtml/blob/master/extensions/amp-form/amp-form.md#redirecting-after-a-submission)). Next, the `GET` handler adds the item to the session, and redirects to the final destination: the `/shopping_cart` page.
     - If the user is visiting the page from its origin, there's no need for a 'double redirect', since the server can access the session directly on the `POST` handler, then add the item to the cart, and, finally redirect to the `/shopping_cart` page.
      -->
 
-     <!-- 
-      The first step of the previous list is necessary, in order to move the user outside the domain of the cache (where the session can't be accessed on browsers that block third party cookies), into an intermediate step in the origin (where the session cookie, is a first party cookie).
+    <!-- 
+    The first step of the previous list is necessary, in order to move the user outside the domain of the cache (where the session can't be accessed on browsers that block third party cookies), into an intermediate step in the origin (where the session cookie, is a first party cookie).
 
-      That way, we can maintain user state across origins, in a secure way, while being compatible with all the major browsers.
-     -->
+    That way, we can maintain user state across origins, in a secure way, while being compatible with all the major browsers.
+    -->
 
       <form id="order" method="POST"
             action-xhr="https://abe-cart-service.glitch.me/add_to_cart"
@@ -773,7 +776,8 @@ This sample showcases how to build a product page in AMP HTML.
           <input type="submit" name="add-to-cart" value="add to cart">
         </div>
         <input type="hidden" name="name" value="Apple">
-        <input type="hidden" name="price" value="$1.99">
+        <input type="hidden" name="price" value="$5.99" [value]="product[product.selectedColor].sizes[product.selectedSize]">
+        <input type="hidden" name="id" value="1" [value]="product[product.selectedColor].id">
         <div submit-error>
           <template type="amp-mustache">
             Error! Looks like something went wrong with your shopping cart, please try to add an item again. {{error}}

--- a/src/60_Samples_%26_Templates/Shopping_Cart.html
+++ b/src/60_Samples_%26_Templates/Shopping_Cart.html
@@ -21,17 +21,31 @@ disablePlayground: true
     .shopping-cart {
       background: #f2f2f2;
     }
-    .details {
+    .item-headline{
+      padding:1rem
+    }
+    .item-details {
       display: flex;
       flex-wrap: wrap;
+      padding-bottom:1rem;
     }
     .shopping-cart > *:nth-child(2n+1) {
       font-weight: 600;
     }
-    .details > * {
+    .item-details > * {
       box-sizing: border-box;
       flex-grow: 1;
       overflow: hidden;
+    }
+    .item-attribute {
+      padding-left:1rem;
+      padding-right:1rem
+    }
+    .delete-button {
+      background: none;
+      box-shadow: none;
+      border-radius: 0px;
+      width:30px
     }
   </style>
 </head>
@@ -54,13 +68,14 @@ disablePlayground: true
                 {{/isEmpty}}
                 {{^isEmpty}}
                 {{#cartItems}}
-                <div class="p1">{{name}} - {{price}}</div>
-                <div class="details pb1">
-                    <div class="px1">Color: {{color}}</div>
-                    <div class="px1">Size: {{size}}</div>
-                    <div class="px1">Qty: {{quantity}}</div>
-                    <button type="button" style="background: none;box-shadow: none;border-radius: 0px;width:30px" on="tap: AMP.setState({cartItem: 
-                                    { size: '{{size}}',
+                <div class="item-headline">{{name}} - {{price}}</div>
+                <div class="item-details">
+                    <div class="item-attribute">Color: {{color}}</div>
+                    <div>Size: {{size}}</div>
+                    <div>Qty: {{quantity}}</div>
+                    <button type="button" class="delete-button" on="tap: AMP.setState({cartItem: 
+                                    { id: '{{id}}',
+                                      size: '{{size}}',
                                       color: '{{color}}'
                                     }}), form-cart-delete.submit">X</button>
                 </div>
@@ -81,6 +96,7 @@ disablePlayground: true
     <form id="form-cart-delete" method="POST" target="_top" action-xhr="https://abe-cart-service.glitch.me/delete-cart-item" on="submit-success: AMP.setState({
                 cartItemsList: event.response
             })" novalidate="">
+        <input type="hidden" name="id" value="" [value]="cartItem.id">
         <input type="hidden" name="color" value="" [value]="cartItem.color">
         <input type="hidden" name="size" value="" [value]="cartItem.size">
     </form>

--- a/src/60_Samples_%26_Templates/Shopping_Cart.html
+++ b/src/60_Samples_%26_Templates/Shopping_Cart.html
@@ -75,8 +75,7 @@ disablePlayground: true
                     <div>Qty: {{quantity}}</div>
                     <button type="button" class="delete-button" on="tap: AMP.setState({cartItem: 
                                     { id: '{{id}}',
-                                      size: '{{size}}',
-                                      color: '{{color}}'
+                                      size: '{{size}}'
                                     }}), form-cart-delete.submit">X</button>
                 </div>
                 <br />
@@ -97,7 +96,6 @@ disablePlayground: true
                 cartItemsList: event.response
             })" novalidate="">
         <input type="hidden" name="id" value="" [value]="cartItem.id">
-        <input type="hidden" name="color" value="" [value]="cartItem.color">
         <input type="hidden" name="size" value="" [value]="cartItem.size">
     </form>
 

--- a/src/Shopping_Cart.html
+++ b/src/Shopping_Cart.html
@@ -9,6 +9,10 @@ disablePlayground: true
 <head>
   <meta charset="utf-8">
   <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
+  <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js"></script>
+  <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
+  <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
   <title>A sample shopping cart</title>
   <link rel="canonical" href="<%host%>/shopping_cart/">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
@@ -32,19 +36,73 @@ disablePlayground: true
   </style>
 </head>
 <body>
-  <!-- ## Shopping Cart -->
-  <!-- A sample shopping cart.
-  <div class="shopping-cart">
-      [[ range $item, $quantity := . ]]
-        <div class="p1">[[$item.Name]] [[$item.Price]]</div>
-        <div class="details pb1">
-          <div class="px1">Color: [[$item.Color]]</div>
-          <div class="px1">Size: [[$item.Size]]</div>
-          <div class="px1">Qty: [[$quantity]]</div>
-        </div>
-      [[ end ]]
+        <div class="shopping-cart">
+        <!-- ## Shopping Cart -->
+        <!-- We use [amp-list](https://www.ampproject.org/docs/reference/components/amp-list), to show a dynamic list of items in the cart.
+        
+        `amp-list` needs to send the session cookie on the header of the request, so that the server can retrieve the contents of the cart on the session. For this reason, we use  [credentails="include"](https://www.ampproject.org/docs/fundamentals/amp-cors-requests#utilizing-cookies-for-cors-requests), as an additional attribute.
+
+        Each row of this list, contains a button to remove items from the cart, that works in the following way:
+
+        2. Clicking on the "remove" button, updates an state object (`cartItem`), which, in turn, update two hidden fields on the form `form-cart-delete`, and also triggers a form submission. This form will call the server to update the cart, and update the `cartItemsList` object with the response.
+        2. The `amp-list` component contains the expression `[src]="cartItemsList.items"`, so that, when the `cartItemsList` object changes, as a result of the previous action, the list gets refreshed with the content of the updated cart.
+        -->
+        <amp-list credentials="include" layout="responsive" height="100px" width="500px" src="https://abe-cart-service.glitch.me/cart_items" [src]="cartItemsList.items">
+            <template type="amp-mustache" id="cart-items">
+                {{#isEmpty}}
+                <h3>Your Basket is Empty. </h3>
+                {{/isEmpty}}
+                {{^isEmpty}}
+                {{#cartItems}}
+                <div class="p1">{{name}} - {{price}}</div>
+                <div class="details pb1">
+                    <div class="px1">Color: {{color}}</div>
+                    <div class="px1">Size: {{size}}</div>
+                    <div class="px1">Qty: {{quantity}}</div>
+                    <button type="button" style="background: none;box-shadow: none;border-radius: 0px;width:30px" on="tap: AMP.setState({cartItem: 
+                                    { size: '{{size}}',
+                                      color: '{{color}}'
+                                    }}), form-cart-delete.submit">X</button>
+                </div>
+                <br />
+                {{/cartItems}}
+                {{/isEmpty}}
+            </template>
+        </amp-list>
     </div>
-    <p>Back to <a href="/samples_templates/product_page/preview/">product</a> sample.</p>
-  -->
+
+    <!-- ## Delete Items Form -->
+    <!-- 
+    As said, we use [amp-form](https://www.ampproject.org/docs/reference/components/amp-form) to send an `XHR POST` request to `/delete-cart-item`:
+
+    1. The form contains two hidden input fields, bound to the `cartItem` object's variables. When the remove button is clicked, this object gets updated with the details of the item to remove from cart, so the form can send them on the call to the server.
+    2. The form updates the `cartItemsList` with the response from the server, so that  `amp-list` can be refreshed with the contents of the updated cart.
+    -->
+    <form id="form-cart-delete" method="POST" target="_top" action-xhr="https://abe-cart-service.glitch.me/delete-cart-item" on="submit-success: AMP.setState({
+                cartItemsList: event.response
+            })" novalidate="">
+        <input type="hidden" name="color" value="" [value]="cartItem.color">
+        <input type="hidden" name="size" value="" [value]="cartItem.size">
+    </form>
+
+
+    <!-- ## Cart List Object -->
+    <!-- This object will be updated after the removal of an item, with the contents of the updated cart. -->  
+    <amp-state id="cartItemsList">
+        <script type="application/json">
+        {
+
+        }
+        </script>
+    </amp-state>
+    <!-- ## Cart Item Object -->
+    <!-- This object acts as a proxy between the action of removing items, and the form submission. -->  
+    <amp-state id="cartItem">
+        <script type="application/json">
+        {
+
+        }
+        </script>
+    </amp-state>
 </body>
 </html>


### PR DESCRIPTION
Changes include:

- Migrating "Add To Cart" functionality from [ABE Product Page](https://ampbyexample.com/samples_templates/product_page/), from CLIENT_ID to sessions, based on best practices.
- Migrating [ABE Shopping Cart Page](https://ampbyexample.com/shopping_cart/) from server-side rendered, to dynamic list, to allow for removal of items from cart.
- Implementing "Remove Item from cart" functionality on Shopping Cart Page.

Notes:

- As discussed with @sebastianbenz, we are temporarily using a Node server on glitch (code [here](https://glitch.com/edit/#!/abe-cart-service)), to host the endpoints required for the different calls, instead of ABE backend.
- The solution uses the "double redirect" pattern, in combination with session usage, to ensure security, and cross-browser compatibility from cache to origin.
- I managed to add the summary of the solution in the product page. When the time comes, we can add a reference to the more detailed cross-origin post, written by @morsssss.
- The changes can be tested by running in localhost, without the need of running the backend server (as it uses a different endpoint). I can help testing on a staging URL, before launching to production, to make sure all use cases work as expected.