### PR TITLE
Replace http://localhost:8080 with <%host%>.

### DIFF
--- a/src/stories/20_Features/Supporting_desktop_and_landscape_mode.html
+++ b/src/stories/20_Features/Supporting_desktop_and_landscape_mode.html
@@ -48,14 +48,14 @@ skipValidation: 'true'
 
       <amp-story-page id="page-1">
         <amp-story-grid-layer template="fill">
-          <amp-img src="http://localhost:8080/img/tree-1920x1277.jpg"
+          <amp-img src="<%host%>/img/tree-1920x1277.jpg"
           width="1920"
           height="1277" layout="responsive"></amp-img>
         </amp-story-grid-layer>
       </amp-story-page>
       <amp-story-page id="page-2">
         <amp-story-grid-layer template="fill">
-          <amp-img src="http://localhost:8080/img/forest-1920x1280.jpg"
+          <amp-img src="<%host%>/img/forest-1920x1280.jpg"
           width="1920"
           height="1280" layout="responsive"></amp-img>
         </amp-story-grid-layer>


### PR DESCRIPTION
When I view [this story](https://ampbyexample.com/stories/features/supporting_desktop_and_landscape_mode/source/), no images are shown. I believe replacing http://localhost:8080 with <%host%> will generate the proper URL for each image: https://ampbyexample.com/img/tree-1920x1277.jpg and https://ampbyexample.com/img/forest-1920x1280.jpg.