### PR TITLE
Fix problem with header id generation

### DIFF
--- a/lib/CodeSection.js
+++ b/lib/CodeSection.js
@@ -20,7 +20,7 @@ const hljs = require('highlight.js');
 const marked = require('marked');
 const renderer = new marked.Renderer();
 renderer.heading = function (text, level) {
-  const escapedText = text.toLowerCase().replace(/[^\w]+/g, '-');
+  const escapedText = text.toLowerCase().replace(/\s+/g, '-');
   return '<h' + level + ' id="' + escapedText +
     '" class="www-heading pb4 mb2 relative h3">' + text + '</h' + level +
     '>';
@@ -245,7 +245,7 @@ module.exports = class CodeSection {
     }
     const name = matches[1].trim().replace(/`/g, '');
     const heading = {
-      id: name.toLowerCase().replace(/[^\w]+/g, '-'),
+      id: name.toLowerCase().replace(/\s+/g, '-'),
       name: name
     };
     this.headings.push(heading);


### PR DESCRIPTION
For the amp docs project the header id generation should match the grow logic:
All characters but whitespace are allowed
See https://github.com/ampproject/docs/issues/1892
And https://github.com/grow/grow/commit/62d0a6aeff8187e6bace24a89b9f74ec8f17e509#diff-506b8f06fee5ce1722a3c180ab3919b7

If there are no side effects to be expected with oder use of the amp-by-example project, please consider accepting this pull request.