### PR TITLE
Allow parseSample to override content

### DIFF
--- a/lib/Standalone.js
+++ b/lib/Standalone.js
@@ -24,8 +24,15 @@ const fs = require('fs');
 const Hogan = require('hogan.js');
 const readFileAsync = promisify(fs.readFile);
 
-module.exports = async (filePath, config) => {
-  let contents = await readFileAsync(filePath, 'utf-8');
+module.exports = {
+  fromPath,
+  load
+};
+
+module.exports = async (filePath, config, contents) => {
+  if (!contents) {
+    contents = await readFileAsync(filePath, 'utf-8');
+  }
   const template = Hogan.compile(contents, {delimiters: '<% %>'});
   contents =  template.render(config);
   const doc = parse(contents);

--- a/lib/Standalone.js
+++ b/lib/Standalone.js
@@ -24,11 +24,6 @@ const fs = require('fs');
 const Hogan = require('hogan.js');
 const readFileAsync = promisify(fs.readFile);
 
-module.exports = {
-  fromPath,
-  load
-};
-
 module.exports = async (filePath, config, contents) => {
   if (!contents) {
     contents = await readFileAsync(filePath, 'utf-8');


### PR DESCRIPTION
Allow `parseSample` to override file contents instead of reading from `fs`. This is useful for on-the-fly processing, e.g. the file was created in-memory and isn't stored on the disk, such as gulp `Vinyl`.

Related to ampproject/docs#2389.