### PR TITLE
Fallback to parent dir name if sample file name is index

### DIFF
--- a/lib/ExampleFile.js
+++ b/lib/ExampleFile.js
@@ -136,7 +136,12 @@ class ExampleFile {
   }
 
   title() {
-    return FileName.toString(this.fileName()).trim();
+    let fileName = this.fileName();
+    if (fileName == 'index.html') {
+      // If the file name is index.html fallback to the parent directory
+      fileName = this.sampleParentDir();
+    }
+    return FileName.toString(fileName).trim();
   }
 
   url() {
@@ -214,4 +219,3 @@ class ExampleFile {
 
 module.exports.fromPath = fromPath;
 module.exports.GITHUB_PREFIX = GITHUB_PREFIX;
-

--- a/spec/compiler/ExampleFileSpec.js
+++ b/spec/compiler/ExampleFileSpec.js
@@ -23,6 +23,10 @@ describe("ExampleFile", function() {
     it('extracts title', function() {
       expect(file.title()).toBe("What's up 100%?");
     });
+    it('use parent directory name as title if filename is index', function() {
+      expect(ExampleFile.fromPath('src/Samples_%26_Templates/index.html')
+        .title()).toBe('Samples & Templates');
+    });
     it('strips leading _', function() {
       expect(ExampleFile.fromPath('src/10_Hello-world/_Hello.html')
         .targetPath()).toBe("hello-world/hello/index.html");


### PR DESCRIPTION
Fixes ampproject/docs#2371.